### PR TITLE
Fix link rot and annotate FT9201 dual-function caveat (#1, #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ git to get them now. Entries are kept for people still on an older libfprint.
 
 | Device ID | Chip / sensor | MR | Merged |
 |-----------|---------------|----|--------|
-| 2808:6553 | FocalTech FT9365 ESS | [!554](https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/554) | 2026-06-18 |
+| 2808:6553 | FocalTech FT9365 ESS ([not the capture function on dual-function FT9201 modules](devices/2808:6553/README.md#caveat-on-dual-function-ft9201-modules)) | [!554](https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/554) | 2026-06-18 |
 | 04f3:0c9c | ELAN ARM-M4 (0c9c) | [!568](https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/568) | 2026-06-18 |
 | 3274:8012 | Microarray match-on-chip | [!492](https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/492) | 2026-06-18 |
 | 298d:2020 | NextBiometrics NB-2020-U | [!569](https://gitlab.freedesktop.org/libfprint/libfprint/-/merge_requests/569) | 2026-07-02 |

--- a/devices/2808:6553/README.md
+++ b/devices/2808:6553/README.md
@@ -19,6 +19,31 @@ on an older libfprint.
 
 Found in the Samsung Galaxy Book 4. Adds the ID to focaltech_moc and accepts status code 0x09 (which the in-tree driver wrongly treated as an error) so enroll completes.
 
+## Caveat on dual-function FT9201 modules
+
+> **This driver is not the right target if your module also exposes `2808:93a9`.**
+
+Some FocalTech modules present **two** USB functions from one physical part:
+`2808:93a9` (the FT9201 image sensor, USB class 255) and `2808:6553` (the FT9365
+secure-storage companion, USB class 220 / Diagnostic). On that hardware,
+`focaltech_moc` binds `6553` and everything *looks* correct - `fprintd-list`
+shows the device, `enroll_times` comes back from the chip, `scan-type = press`,
+and `EnrollStart` is accepted - but it never captures, because there is no
+sensor on that function. A reported `usbmon` trace over a 120 s enroll with the
+sensor being touched continuously shows the finger poll answered with one
+identical response 2249 times, with no variation; enroll then sits in
+`MOC_IDENTIFY` until it cancels. **No error is surfaced**, so it presents as a
+broken sensor rather than as the wrong function.
+
+Capture on those modules has to go through `93a9` - see
+[`devices/2808:9338`](../2808:9338/). Standalone `6553` devices (such as the
+Galaxy Book 4 hardware this MR was written and verified against) are unaffected;
+this is a note about which function to bind, not a defect in !554.
+
+Reported in [issue #2](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/2)
+by @NBN-N3 (Kali, kernel 6.17), on a single module - corroboration from other
+dual-function hardware is welcome.
+
 ## How to use it
 
 The code lives in the merge request, not in this repo. To try it, check out the

--- a/devices/2808:9338/README.md
+++ b/devices/2808:9338/README.md
@@ -18,6 +18,27 @@ people with this sensor can find and build the work in progress.
 
 New driver for the FocalTech FT9201 sensor.
 
+## Hardware notes (measured, `2808:93a9`)
+
+Reported in [issue #2](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/2)
+from a live device, and worth recording because a couple of write-ups assume
+otherwise:
+
+- USB interface class **255** (vendor-specific), `bcdDevice 1.00`.
+- **Exactly two bulk endpoints and no interrupt endpoint**: `0x02` OUT (16 B),
+  `0x83` IN (32 B). Several existing descriptions assume an interrupt endpoint
+  on `93a9`; there is none on this revision.
+- Image is 64x80, 8 bpp, read as exactly `width * height` bytes.
+- Vendor request **`0x6F`** (length in `wValue`, address in `wIndex`) is what
+  arms a bulk read here. Open drivers that use `0x35` arm nothing on this
+  revision - a plausible explanation for the long-standing "initialises but
+  never reads" reports against this sensor.
+
+Some modules also expose `2808:6553` alongside `93a9`. That second function is
+the FT9365 secure-storage companion and cannot capture, even though
+`focaltech_moc` binds it and it answers the protocol - see the
+[caveat in `devices/2808:6553`](../2808:6553/README.md#caveat-on-dual-function-ft9201-modules).
+
 ## How to use it
 
 The code lives in the merge request, not in this repo. To try it, check out the
@@ -53,7 +74,37 @@ Trade-offs: you must supply the vendor DLL yourself, matching happens inside a
 blob nobody can fix, and it is x86-64 only. Tested by that author on the FT9348W
 variant of `2808:93a9`.
 
-Its [`PORTING.md`](https://github.com/OMGrant/ft9201-libfprint/blob/main/PORTING.md)
+Its [`PORTING.md`](https://github.com/OMGrant/ft9201-libfprint/blob/HEAD/PORTING.md)
 generalises the method to other Windows-Hello-only readers, including SDCP
 sensors, which makes it worth reading for anyone attacking a sensor in the
 [gap-map](../../docs/unsupported-devices.md).
+
+## Alternative route: clean-room protocol spec (captures, does not match)
+
+[NBN-PATRIC/ft9201-libfprint](https://github.com/NBN-PATRIC/ft9201-libfprint)
+(LGPL-2.1, clean-room, no blobs) documents the `2808:93a9` protocol and ships a
+WIP driver built on it. **It captures but does not authenticate** - the author
+is explicit about this, and so is the driver header.
+
+What works: acquisition against libfprint master (1.94.100), `fprintd`
+recognises the device, frames are captured, ridge structure resolves at an
+8-14 px period, and enrollment completes.
+
+What does not: verification never matches, and the author's follow-up
+measurements argue this is **not** a tuning problem. NBIS minutiae extraction
+yields under 3 minutiae per frame against a Bozorth threshold of 40;
+multi-frame mosaicking raises the count with seam artifacts that score 0
+between two composites of the same finger; and NCC over subtemplates separates
+genuine from impostor by d' = 0.06 in natural use. Fixed-pattern-noise removal,
+a wider rotation search, Gabor ridge enhancement and larger scoring windows
+were all measured and none closed the gap. The stated root cause is window
+size: at 3.2 x 4.1 mm, eleven natural touches spanned essentially the full
+rotation range, so a physically rotated finger presents a *different patch of
+skin* rather than a rotated copy of the same one - synthetic rotation of one
+sample is recovered at 0.98, so the rotation search itself is fine.
+
+The sensor is not the limitation - the vendor library authenticates on this
+same hardware - so closing the gap means reproducing a proprietary feature
+extractor. Treat the repo as a protocol reference and capture path, not as a
+working login. See its `MATCHING.md` for the full account and `tuning/` for the
+harnesses.

--- a/docs/unsupported-devices.md
+++ b/docs/unsupported-devices.md
@@ -8,10 +8,17 @@ an entry in [`devices/`](../devices/) (working or WIP) are omitted - check the
 have one of these, a protocol dump or a driver is welcome.
 
 "Lead" flags a known reverse-engineering effort, partial result, or WIP/PoC
-noted on the wiki; follow the device's wiki page for links.
+noted on the wiki.
 
 Source: libfprint wiki, fetched 2026-06-18. Rows are removed as devices gain
-an entry; last reconciled 2026-07-26.
+an entry; last reconciled 2026-08-02.
+
+Most USB IDs below are plain text rather than links: the wiki's own
+`Unsupported-Devices` table links each device to a `Devices/<id>` subpage, but
+only 2 of the 104 pages have ever been written, so the rest are dangling links
+upstream. The two that exist are linked; for the others, start from the
+[Unsupported Devices](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Unsupported-Devices)
+page itself, which carries the per-device notes inline.
 
 Two clusters listed below do now have WIP driver work tracked in the README:
 the Dell **`0a5c:58xx` Broadcom** family is targeted by the ControlVault3 driver
@@ -22,110 +29,110 @@ VCSFW driver (MR [!579](https://gitlab.freedesktop.org/libfprint/libfprint/-/mer
 
 | USB ID | Hardware | Lead |
 |--------|----------|------|
-| [047d:00f2](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/047d:00f2) | External (USB) |  |
-| [047d:8054](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/047d:8054) | External (USB) |  |
-| [047d:8055](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/047d:8055) | External (USB) |  |
-| [04f3:036b](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:036b) | - |  |
-| [04f3:0c57](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c57) | Lenovo IdeaPad 3-15ARE05 |  |
-| [04f3:0c5a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c5a) | Surface Laptop Go |  |
-| [04f3:0c5e](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c5e) | HP Probook 450 G8 |  |
+| `047d:00f2` | External (USB) |  |
+| `047d:8054` | External (USB) |  |
+| `047d:8055` | External (USB) |  |
+| `04f3:036b` | - |  |
+| `04f3:0c57` | Lenovo IdeaPad 3-15ARE05 |  |
+| `04f3:0c5a` | Surface Laptop Go |  |
+| `04f3:0c5e` | HP Probook 450 G8 |  |
 | [04f3:0c60](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c60) | Lenovo Optical Mouse |  |
-| [04f3:0c70](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c70) | Redmi Book Pro, 14" AMD |  |
-| [04f3:0c72](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c72) | Acer Swift 3 SF314-43 |  |
-| [04f3:0c77](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c77) | - | partial |
-| [04f3:0c7c](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c7c) | - | WIP/PoC upstream |
-| [04f3:0c7f](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c7f) | Acer Swift 3 |  |
-| [04f3:0c80](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c80) | ELAN:ARM-M4 - Surface Laptop Go 2 |  |
-| [04f3:0c85](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c85) | ELAN:ARM-M4 ACER Aspire Vero |  |
-| [04f3:0c8a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c8a) | - |  |
-| [04f3:0c90](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:0c90) | ELAN:ARM-M4 ASUS Vivobook |  |
-| [04f3:2706](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:2706) | Asus Zenbook Pro UX580 |  |
-| [04f3:3032](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:3032) | ASUS ZenBook UX330CA |  |
-| [04f3:3057](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:3057) | ASUS VivoBook Pro 15 N580GD |  |
-| [04f3:3104](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:3104) | ASUS Vivobook f571gt- al318t | partial |
-| [04f3:3128](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/04f3:3128) | ELAN/FA461D-2203 |  |
-| [05ba:000e](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/05ba:000e) | DigitalPersona 5300 |  |
+| `04f3:0c70` | Redmi Book Pro, 14" AMD |  |
+| `04f3:0c72` | Acer Swift 3 SF314-43 |  |
+| `04f3:0c77` | - | partial |
+| `04f3:0c7c` | - | WIP/PoC upstream |
+| `04f3:0c7f` | Acer Swift 3 |  |
+| `04f3:0c80` | ELAN:ARM-M4 - Surface Laptop Go 2 |  |
+| `04f3:0c85` | ELAN:ARM-M4 ACER Aspire Vero |  |
+| `04f3:0c8a` | - |  |
+| `04f3:0c90` | ELAN:ARM-M4 ASUS Vivobook |  |
+| `04f3:2706` | Asus Zenbook Pro UX580 |  |
+| `04f3:3032` | ASUS ZenBook UX330CA |  |
+| `04f3:3057` | ASUS VivoBook Pro 15 N580GD |  |
+| `04f3:3104` | ASUS Vivobook f571gt- al318t | partial |
+| `04f3:3128` | ELAN/FA461D-2203 |  |
+| `05ba:000e` | DigitalPersona 5300 |  |
 | [06cb:0051](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:0051) | - |  |
-| [06cb:0081](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:0081) | lenovo Yoga 720 |  |
-| [06cb:0088](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:0088) | External, Validity90 project is relevant |  |
-| [06cb:008a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:008a) | Toshiba B2B-range X30-D and X40-D |  |
-| [06cb:009b](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:009b) | MSI Prestige 14 A10RB |  |
-| [06cb:00a1](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00a1) | Validity90 |  |
-| [06cb:00a2](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00a2) | Validity90 |  |
-| [06cb:00a8](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00a8) | Clevo Laptops |  |
-| [06cb:00bb](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00bb) | HP Spectre x360 - 13 -ap0xxxxx |  |
-| [06cb:00bc](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00bc) | dell latitude 7200 |  |
-| [06cb:00be](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00be) | Thinkpad C740, Yoga | RE effort exists |
-| [06cb:00d8](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00d8) | HP ProBook 430 G7 |  |
-| [06cb:00da](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00da) | ThinkPad E14 |  |
-| [06cb:00dc](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00dc) | Acer Spin 3, SP313-51N |  |
-| [06cb:00e4](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00e4) | Acer ConceptD CC314-72 |  |
-| [06cb:00fd](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/06cb:00fd) | Lenovo Thinkbook 15 G13 |  |
-| [0a5c:5801](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5801) | Dell Latitude E6530 |  |
-| [0a5c:5802](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5802) | Dell Precision M4800 |  |
-| [0a5c:5805](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5805) | Dell Latitude e5470 |  |
-| [0a5c:5834](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5834) | Dell Latitude 7480 |  |
-| [0a5c:5840](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5840) | - |  |
-| [0a5c:5841](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5841) | - |  |
-| [0a5c:5842](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5842) | Dell Precision 7550 |  |
-| [0a5c:5843](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5843) | Dell Latitude 7300 |  |
-| [0a5c:5844](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5844) | - |  |
-| [0a5c:5845](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5845) | - |  |
-| [0a5c:5860](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5860) | - |  |
-| [0a5c:5863](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5863) | - |  |
-| [0a5c:5864](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5864) | Broadcom Corp. 58200 |  |
-| [0a5c:5865](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5865) | - |  |
-| [0a5c:5866](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5866) | - |  |
-| [0a5c:5867](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0a5c:5867) | - |  |
-| [0bda:5812](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/0bda:5812) | Lenovo Yoga 9i 14ITL |  |
-| [10a5:0007](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/10a5:0007) | LG GRAM 2018 |  |
-| [10a5:a120](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/10a5:a120) | - |  |
-| [10a5:a900](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/10a5:a900) | magikbook 14x |  |
-| [10a5:a921](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/10a5:a921) | Honor Magicbook x16 plus 2024 |  |
-| [10a5:e340](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/10a5:e340) | Acer Swift 3 OLED (SF314-71-56U3) |  |
-| [1188:9545](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/1188:9545) | - |  |
-| [138a:0007](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:0007) | - |  |
-| [138a:003a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:003a) | HP 640 G4 Notebook |  |
-| [138a:003c](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:003c) | HP EliteBook 8560w |  |
-| [138a:003d](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:003d) | HP EliteBook 8770w |  |
-| [138a:003f](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:003f) | HP Zbook 15 G2 / HP Probook 430 |  |
-| [138a:0092](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:0092) | HP EliteBook 1040 G4 |  |
-| [138a:0094](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:0094) | - |  |
-| [138a:009d](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:009d) | - |  |
-| [138a:00a6](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/138a:00a6) | Dell Latitude 3490 |  |
-| [1491:0088](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/1491:0088) | - |  |
-| [16d1:1027](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/16d1:1027) | - |  |
-| [1c7a:0300](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/1c7a:0300) | Acer Swift 1 (SF114-32-P78E)? | RE effort exists |
-| [1c7a:0577](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/1c7a:0577) | GTR5 mini |  |
-| [1c7a:057e](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/1c7a:057e) | Samsung GalaxyBook Pro 360 |  |
-| [27c6:5042](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5042) | External |  |
-| [27c6:5117](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5117) | MagicBook 2019 R7 / Huawei Matebook 13 2020 |  |
-| [27c6:5120](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5120) | Matebook D16 |  |
-| [27c6:5125](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5125) | HONOR HYM-WXX MagicBook 16 |  |
-| [27c6:5201](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5201) | ASUS ZenBook S UX391FA-AH001T |  |
-| [27c6:5301](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5301) | - |  |
-| [27c6:530c](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:530c) | Dell G5 15 5590 |  |
-| [27c6:532d](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:532d) | Dell XPS 13 7390 2-in-1 |  |
-| [27c6:5381](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5381) | - |  |
-| [27c6:538c](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:538c) | Dell Inspiron 17 7000 |  |
-| [27c6:538d](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:538d) | Dell Inspiron 17 7000 |  |
-| [27c6:5503](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5503) | Lenovo ThinkPad E14 |  |
-| [27c6:550c](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:550c) | Lenovo Yoga 9 14IAP7 |  |
-| [27c6:5584](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5584) | yoga 730-13IWL 81JR |  |
-| [27c6:55a2](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:55a2) | Ideapad 5 |  |
-| [27c6:55a4](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:55a4) | Thinkpad E14 / Thinkbook 13s-IWL |  |
-| [27c6:5740](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5740) | Teclast F6 Pro |  |
-| [27c6:581a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:581a) | Mi RedmiBook Pro |  |
-| [27c6:589a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:589a) | Mi RedmiBook 15 2022 Pro |  |
-| [27c6:5e0a](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5e0a) | realme book MP |  |
-| [27c6:5f10](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5f10) | Honor MagicBook X16Pro Ryzen 7 7840HS |  |
-| [27c6:5f91](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:5f91) | Honor Magicbook Art 14 |  |
-| [27c6:6382](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/27c6:6382) | Dell XPS 9315 2-in-1 |  |
-| [2808:9348](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/2808:9348) | - |  |
-| [2808:a553](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/2808:a553) | Focaltech FT9365, Asus VivoBook |  |
-| [2808:a658](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/2808:a658) | Asus Vivobook K6500zc |  |
-| [2df0:0003](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/2df0:0003) | CanvasBio CB2000 |  |
-| [3538:0930](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Devices/3538:0930) | External |  |
+| `06cb:0081` | lenovo Yoga 720 |  |
+| `06cb:0088` | External, Validity90 project is relevant |  |
+| `06cb:008a` | Toshiba B2B-range X30-D and X40-D |  |
+| `06cb:009b` | MSI Prestige 14 A10RB |  |
+| `06cb:00a1` | Validity90 |  |
+| `06cb:00a2` | Validity90 |  |
+| `06cb:00a8` | Clevo Laptops |  |
+| `06cb:00bb` | HP Spectre x360 - 13 -ap0xxxxx |  |
+| `06cb:00bc` | dell latitude 7200 |  |
+| `06cb:00be` | Thinkpad C740, Yoga | RE effort exists |
+| `06cb:00d8` | HP ProBook 430 G7 |  |
+| `06cb:00da` | ThinkPad E14 |  |
+| `06cb:00dc` | Acer Spin 3, SP313-51N |  |
+| `06cb:00e4` | Acer ConceptD CC314-72 |  |
+| `06cb:00fd` | Lenovo Thinkbook 15 G13 |  |
+| `0a5c:5801` | Dell Latitude E6530 |  |
+| `0a5c:5802` | Dell Precision M4800 |  |
+| `0a5c:5805` | Dell Latitude e5470 |  |
+| `0a5c:5834` | Dell Latitude 7480 |  |
+| `0a5c:5840` | - |  |
+| `0a5c:5841` | - |  |
+| `0a5c:5842` | Dell Precision 7550 |  |
+| `0a5c:5843` | Dell Latitude 7300 |  |
+| `0a5c:5844` | - |  |
+| `0a5c:5845` | - |  |
+| `0a5c:5860` | - |  |
+| `0a5c:5863` | - |  |
+| `0a5c:5864` | Broadcom Corp. 58200 |  |
+| `0a5c:5865` | - |  |
+| `0a5c:5866` | - |  |
+| `0a5c:5867` | - |  |
+| `0bda:5812` | Lenovo Yoga 9i 14ITL |  |
+| `10a5:0007` | LG GRAM 2018 |  |
+| `10a5:a120` | - |  |
+| `10a5:a900` | magikbook 14x |  |
+| `10a5:a921` | Honor Magicbook x16 plus 2024 |  |
+| `10a5:e340` | Acer Swift 3 OLED (SF314-71-56U3) |  |
+| `1188:9545` | - |  |
+| `138a:0007` | - |  |
+| `138a:003a` | HP 640 G4 Notebook |  |
+| `138a:003c` | HP EliteBook 8560w |  |
+| `138a:003d` | HP EliteBook 8770w |  |
+| `138a:003f` | HP Zbook 15 G2 / HP Probook 430 |  |
+| `138a:0092` | HP EliteBook 1040 G4 |  |
+| `138a:0094` | - |  |
+| `138a:009d` | - |  |
+| `138a:00a6` | Dell Latitude 3490 |  |
+| `1491:0088` | - |  |
+| `16d1:1027` | - |  |
+| `1c7a:0300` | Acer Swift 1 (SF114-32-P78E)? | RE effort exists |
+| `1c7a:0577` | GTR5 mini |  |
+| `1c7a:057e` | Samsung GalaxyBook Pro 360 |  |
+| `27c6:5042` | External |  |
+| `27c6:5117` | MagicBook 2019 R7 / Huawei Matebook 13 2020 |  |
+| `27c6:5120` | Matebook D16 |  |
+| `27c6:5125` | HONOR HYM-WXX MagicBook 16 |  |
+| `27c6:5201` | ASUS ZenBook S UX391FA-AH001T |  |
+| `27c6:5301` | - |  |
+| `27c6:530c` | Dell G5 15 5590 |  |
+| `27c6:532d` | Dell XPS 13 7390 2-in-1 |  |
+| `27c6:5381` | - |  |
+| `27c6:538c` | Dell Inspiron 17 7000 |  |
+| `27c6:538d` | Dell Inspiron 17 7000 |  |
+| `27c6:5503` | Lenovo ThinkPad E14 |  |
+| `27c6:550c` | Lenovo Yoga 9 14IAP7 |  |
+| `27c6:5584` | yoga 730-13IWL 81JR |  |
+| `27c6:55a2` | Ideapad 5 |  |
+| `27c6:55a4` | Thinkpad E14 / Thinkbook 13s-IWL |  |
+| `27c6:5740` | Teclast F6 Pro |  |
+| `27c6:581a` | Mi RedmiBook Pro |  |
+| `27c6:589a` | Mi RedmiBook 15 2022 Pro |  |
+| `27c6:5e0a` | realme book MP |  |
+| `27c6:5f10` | Honor MagicBook X16Pro Ryzen 7 7840HS |  |
+| `27c6:5f91` | Honor Magicbook Art 14 |  |
+| `27c6:6382` | Dell XPS 9315 2-in-1 |  |
+| `2808:9348` | - |  |
+| `2808:a553` | Focaltech FT9365, Asus VivoBook |  |
+| `2808:a658` | Asus Vivobook K6500zc |  |
+| `2df0:0003` | CanvasBio CB2000 |  |
+| `3538:0930` | External |  |
 
 _SPI sensors (ELAN7001/7002/079C, GXFP5187/51B7, GDIX51C0, fpc1020, etc.) are
 also unsupported; see the wiki's SPI Devices section._


### PR DESCRIPTION
Closes #1. Addresses #2 (leaving that one open until the reporter confirms the wording).

## #1 - link rot (103 broken links)

The weekly check flagged 102 links in `docs/unsupported-devices.md` plus 1 elsewhere.

**The 102 are inherited, not ours.** The libfprint wiki's own `Unsupported-Devices` table links every device to a `Devices/<id>` subpage, and almost none of those pages were ever written - they are dangling links upstream too. I checked all 104 IDs against the wiki: **only `04f3:0c60` and `06cb:0051` exist**. Kept those two linked, made the other 102 plain `code`, and said why in the preamble so nobody "helpfully" re-adds them.

**The 1 other** was `OMGrant/ft9201-libfprint`'s `PORTING.md` - the file is fine, the repo's default branch is `master`, not `main`. Switched to `/blob/HEAD/` so it survives a future rename.

## #2 - FT9201 dual-function caveat

Annotated the `2808:6553` entry roughly as @NBN-N3 drafted it, keeping their hedge: on modules exposing both `93a9` and `6553`, the `6553` function is the FT9365 secure-storage companion - `focaltech_moc` binds it, it answers the protocol and reports enroll stages, but it has no sensor and never reports a finger, and **no error is surfaced**. Standalone `6553` (the Galaxy Book 4 hardware !554 was verified on) is unaffected, so this is not framed as a defect in !554.

Also folded in from that thread, into `devices/2808:9338`:
- measured descriptors - class 255, **two bulk endpoints and no interrupt endpoint**, 64x80 8bpp. Several write-ups assume an interrupt endpoint on `93a9`; there is not one on this revision.
- vendor request **`0x6F`** as what actually arms a bulk read (open drivers use `0x35`, which arms nothing here) - a plausible explanation for the long-standing "initialises but never reads" reports.
- `NBN-PATRIC/ft9201-libfprint` as a clean-room protocol reference, documented as **captures but does not authenticate**, with the author's own measurements for why that is a research problem rather than a tuning one.

## Checks

- `python3 tools/check-repo.py` - OK, 41 entries, all links and files consistent
- every external URL in the 4 touched files returns 200 (40 URLs)
- MR states re-verified against the GitLab API: !554 merged 2026-06-18, !572 still open