### PR TITLE
Add a by-laptop-model index and a generated GitHub Pages site

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-report.yml
+++ b/.github/ISSUE_TEMPLATE/device-report.yml
@@ -44,6 +44,10 @@ body:
     id: hardware
     attributes:
       label: Hardware
+      description: >-
+        The exact laptop model, as the vendor names it. This is what gets added
+        to the by-model index (docs/laptops.md), so the next person with your
+        machine finds the entry without having to know their USB ID.
       placeholder: Lenovo Yoga 9 14IAP7
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
       - name: Structure, README and link consistency
         run: python3 tools/check-repo.py
 
+      - name: Laptop index is up to date
+        run: python3 tools/gen-laptop-index.py --check
+
+      - name: Site builds
+        run: |
+          pip install --quiet markdown
+          python3 tools/build-site.py
+
       - name: Lint shell scripts
         run: |
           sudo apt-get update -qq

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Only the deploy needs write scope; the build job runs with the default read.
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install renderer
+        run: pip install --quiet markdown
+
+      - name: Build site
+        run: python3 tools/build-site.py
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+site/
+__pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ works (or has broken) on your distro, or a protocol dump for something in the
 devices/<vendor>:<product>/
   README.md      # required - sensor info + build/install/setup instructions
   CREDITS        # required - author(s) and links to upstream fork/branch
+  MODELS         # optional - one laptop model per line, feeds docs/laptops.md
   patches/       # patch files (.patch / .diff) against a stated libfprint base
     .gitkeep
 ```
@@ -48,6 +49,31 @@ devices/<vendor>:<product>/
   patches come from, so changes can be traced and credited.
 - **patches/** - the actual `.patch`/`.diff` files, or a clear pointer to the
   branch they live on. State the libfprint version/commit they apply against.
+
+### MODELS (optional, and very welcome)
+
+Almost nobody knows their sensor's USB ID before they go looking; they know
+they own a ThinkPad. `MODELS` is how a machine name becomes findable. One
+model per line, no bullets or other markup, named the way the vendor names it:
+
+```
+Lenovo ThinkPad E14 Gen 4
+Lenovo ThinkPad E15
+```
+
+It is read by `tools/gen-laptop-index.py`, which regenerates
+[docs/laptops.md](docs/laptops.md), and by `tools/build-site.py`, which puts the
+model names in the published page's title. After editing one, run:
+
+```sh
+python3 tools/gen-laptop-index.py
+```
+
+and commit the regenerated `docs/laptops.md` alongside it. CI fails if the two
+are out of step. Do not edit `docs/laptops.md` directly.
+
+Only list machines somebody has actually seen the sensor in. A guess here sends
+the next person down the wrong path.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ sensors that are **not yet supported in upstream
 If your sensor shows up in `lsusb` but `fprintd-enroll` fails or the device is
 unknown to libfprint, there may be a working fix here, or you can contribute one.
 
+Browsable as a website, one page per sensor:
+**<https://jedbillyb.github.io/linux-fingerprint-drivers/>**
+
 **Check upstream first:** if your reader is on libfprint's own
 [supported devices](https://fprint.freedesktop.org/supported-devices.html) list,
 use your distro's libfprint. This repo is only for the ones that are not.
 
+- [**Find your laptop by model**](docs/laptops.md) - start here if you do not know your USB ID
 - [Find your device](#find-your-device)
 - [Working fixes](#working-fixes)
 - [In progress (unmerged upstream MRs)](#in-progress-unmerged-upstream-mrs)
@@ -25,8 +29,14 @@ use your distro's libfprint. This repo is only for the ones that are not.
 
 ## Find your device
 
-Clone the repo and let the helper script match your hardware against everything
-catalogued here:
+**Know your laptop but not your sensor?** Look your machine up in
+**[docs/laptops.md](docs/laptops.md)**, an index of every laptop model named
+anywhere in this repo or on the libfprint wiki, mapped to its USB ID and the
+route that works. Adding your own model there is the most useful small
+contribution you can make.
+
+Otherwise, clone the repo and let the helper script match your hardware against
+everything catalogued here:
 
 ```sh
 git clone https://github.com/jedbillyb/linux-fingerprint-drivers.git

--- a/devices/04f3:0c4b/MODELS
+++ b/devices/04f3:0c4b/MODELS
@@ -1,0 +1,1 @@
+Lenovo ThinkPad E14 Gen 4

--- a/devices/06cb:00b7/MODELS
+++ b/devices/06cb:00b7/MODELS
@@ -1,0 +1,2 @@
+HP ProBook 450 G6
+HP ZBook 17 G6

--- a/devices/06cb:00cb/MODELS
+++ b/devices/06cb:00cb/MODELS
@@ -1,0 +1,1 @@
+HP Pavilion x360 14-dh

--- a/devices/06cb:00ff/MODELS
+++ b/devices/06cb:00ff/MODELS
@@ -1,0 +1,4 @@
+HP EliteBook
+HP ProBook
+HP Envy
+HP Spectre

--- a/devices/10a5:9201/MODELS
+++ b/devices/10a5:9201/MODELS
@@ -1,0 +1,1 @@
+Xiaomi RedmiBook 14 Pro

--- a/devices/10a5:9800/MODELS
+++ b/devices/10a5:9800/MODELS
@@ -1,0 +1,1 @@
+Lenovo ThinkPad E14 Gen 5

--- a/devices/138a:0097/MODELS
+++ b/devices/138a:0097/MODELS
@@ -1,0 +1,4 @@
+Lenovo ThinkPad T480
+Lenovo ThinkPad T480s
+Lenovo ThinkPad T580
+Lenovo ThinkPad X1 Carbon Gen 6

--- a/devices/138a:00ab/MODELS
+++ b/devices/138a:00ab/MODELS
@@ -1,0 +1,1 @@
+HP ZBook Studio x360 G5

--- a/devices/2541:0236/MODELS
+++ b/devices/2541:0236/MODELS
@@ -1,0 +1,2 @@
+GPD Win Max 2
+AYANEO 2

--- a/devices/27c6:533c/MODELS
+++ b/devices/27c6:533c/MODELS
@@ -1,0 +1,2 @@
+Dell XPS 13 9300
+Dell XPS 15 9500

--- a/devices/27c6:5385/MODELS
+++ b/devices/27c6:5385/MODELS
@@ -1,0 +1,3 @@
+Dell XPS 13 9305
+Dell XPS 13 7390 2-in-1
+Dell XPS 15 9570

--- a/devices/27c6:550a/MODELS
+++ b/devices/27c6:550a/MODELS
@@ -1,0 +1,3 @@
+Lenovo ThinkPad E14
+Lenovo ThinkPad E15
+Lenovo ThinkBook

--- a/devices/2808:6553/MODELS
+++ b/devices/2808:6553/MODELS
@@ -1,0 +1,1 @@
+Samsung Galaxy Book 4

--- a/devices/broadcom-controlvault3/MODELS
+++ b/devices/broadcom-controlvault3/MODELS
@@ -1,0 +1,1 @@
+Dell Latitude 7300

--- a/docs/laptops.md
+++ b/docs/laptops.md
@@ -1,0 +1,216 @@
+# Find your laptop
+
+Fingerprint reader support on Linux, indexed by **laptop model** rather
+than by USB ID. If `fprintd-enroll` fails on your machine, find it below.
+
+This page is generated from the device entries and the
+[gap-map](unsupported-devices.md); it lists every model those name, and
+nothing else. Absence from this page is not evidence that a reader works
+or does not: it usually just means nobody has reported that model yet.
+Many sensors also ship in machines nobody has written down here, so if
+your exact model is missing, **match on the USB ID instead**:
+
+```sh
+lsusb        # find the reader, e.g. 27c6:55b4
+```
+
+then look it up in the [main README](../README.md), or run
+`./tools/detect.sh` to have it matched for you.
+
+27 model listings map to a catalogued sensor; the rest are on the
+gap-map with no known fix, and a protocol dump for any of them is welcome.
+
+**Adding your machine** is the single most useful small contribution here.
+Open a [device report](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/new?template=device-report.yml)
+with your model and `lsusb` line, or add a line to the sensor's
+`devices/<id>/MODELS` file and open a PR.
+
+Status legend: **Working** (enroll and verify reliable), **Working (vendor
+blob)** (only via a proprietary driver, see the entry's caveats),
+**Partial**, **Merged upstream** (in libfprint git, build from source),
+**WIP** (unmerged work exists), **Unreliable** (claimed upstream but fails
+in practice), **Stale** (abandoned lead), **No known fix**.
+
+## Lenovo
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| Lenovo ThinkPad E14 Gen 5 | `10a5:9800` | FPC Match-on-Host / fpcmoh | Working | [entry](../devices/10a5:9800/) |
+| Lenovo ThinkBook | `27c6:550a` | Goodix 550a - vendor TOD blob route | Working (vendor blob) | [entry](../devices/27c6:550a/) |
+| Lenovo ThinkPad E14 | `27c6:550a` | Goodix 550a - vendor TOD blob route | Working (vendor blob) | [entry](../devices/27c6:550a/) |
+| Lenovo ThinkPad E14 Gen 4 | `04f3:0c4b` | ELAN 0c4b - Lenovo TOD blob route | Working (vendor blob) | [entry](../devices/04f3:0c4b/) |
+| Lenovo ThinkPad E15 | `27c6:550a` | Goodix 550a - vendor TOD blob route | Working (vendor blob) | [entry](../devices/27c6:550a/) |
+| Lenovo ThinkPad T480 | `138a:0097` | Validity/Synaptics VFS0097 (VCSFW) | WIP | [entry](../devices/138a:0097/) |
+| Lenovo ThinkPad T480s | `138a:0097` | Validity/Synaptics VFS0097 (VCSFW) | WIP | [entry](../devices/138a:0097/) |
+| Lenovo ThinkPad T580 | `138a:0097` | Validity/Synaptics VFS0097 (VCSFW) | WIP | [entry](../devices/138a:0097/) |
+| Lenovo ThinkPad X1 Carbon Gen 6 | `138a:0097` | Validity/Synaptics VFS0097 (VCSFW) | WIP | [entry](../devices/138a:0097/) |
+| Ideapad 5 | `27c6:55a2` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Lenovo IdeaPad 3-15ARE05 | `04f3:0c57` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Lenovo Thinkbook 15 G13 | `06cb:00fd` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Lenovo ThinkPad E14 | `27c6:5503` | - | No known fix | [gap-map](unsupported-devices.md) |
+| lenovo Yoga 720 | `06cb:0081` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Lenovo Yoga 9 14IAP7 | `27c6:550c` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Lenovo Yoga 9i 14ITL | `0bda:5812` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Thinkpad C740, Yoga | `06cb:00be` | lead: RE effort exists | No known fix | [gap-map](unsupported-devices.md) |
+| ThinkPad E14 | `06cb:00da` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Thinkpad E14 / Thinkbook 13s-IWL | `27c6:55a4` | - | No known fix | [gap-map](unsupported-devices.md) |
+| yoga 730-13IWL 81JR | `27c6:5584` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Dell
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| Dell XPS 13 7390 2-in-1 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
+| Dell XPS 13 9305 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
+| Dell XPS 15 9570 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
+| Dell XPS 13 9300 | `27c6:533c` | Goodix 533c - Dell OEM TOD blob route | Working (vendor blob) | [entry](../devices/27c6:533c/) |
+| Dell XPS 15 9500 | `27c6:533c` | Goodix 533c - Dell OEM TOD blob route | Working (vendor blob) | [entry](../devices/27c6:533c/) |
+| Dell Latitude 7300 | `broadcom-controlvault3` | Broadcom ControlVault3 (Dell) | WIP | [entry](../devices/broadcom-controlvault3/) |
+| Dell G5 15 5590 | `27c6:530c` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Inspiron 17 7000 | `27c6:538c` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Inspiron 17 7000 | `27c6:538d` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Latitude 3490 | `138a:00a6` | - | No known fix | [gap-map](unsupported-devices.md) |
+| dell latitude 7200 | `06cb:00bc` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Latitude 7300 | `0a5c:5843` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Latitude 7480 | `0a5c:5834` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Latitude e5470 | `0a5c:5805` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Latitude E6530 | `0a5c:5801` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Precision 7550 | `0a5c:5842` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell Precision M4800 | `0a5c:5802` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell XPS 13 7390 2-in-1 | `27c6:532d` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Dell XPS 9315 2-in-1 | `27c6:6382` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## HP
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| HP EliteBook | `06cb:00ff` | Synaptics Tudor match-in-sensor family | Working | [entry](../devices/06cb:00ff/) |
+| HP Envy | `06cb:00ff` | Synaptics Tudor match-in-sensor family | Working | [entry](../devices/06cb:00ff/) |
+| HP ProBook | `06cb:00ff` | Synaptics Tudor match-in-sensor family | Working | [entry](../devices/06cb:00ff/) |
+| HP Spectre | `06cb:00ff` | Synaptics Tudor match-in-sensor family | Working | [entry](../devices/06cb:00ff/) |
+| HP Pavilion x360 14-dh | `06cb:00cb` | Validity/Synaptics VCSFW 0x969 | WIP | [entry](../devices/06cb:00cb/) |
+| HP ProBook 450 G6 | `06cb:00b7` | Validity/Synaptics VCSFW 0xd51 | WIP | [entry](../devices/06cb:00b7/) |
+| HP ZBook 17 G6 | `06cb:00b7` | Validity/Synaptics VCSFW 0xd51 | WIP | [entry](../devices/06cb:00b7/) |
+| HP ZBook Studio x360 G5 | `138a:00ab` | Validity/Synaptics VCSFW 0x969 | WIP | [entry](../devices/138a:00ab/) |
+| HP 640 G4 Notebook | `138a:003a` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP EliteBook 1040 G4 | `138a:0092` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP EliteBook 8560w | `138a:003c` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP EliteBook 8770w | `138a:003d` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP ProBook 430 G7 | `06cb:00d8` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP Probook 450 G8 | `04f3:0c5e` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP Spectre x360 - 13 -ap0xxxxx | `06cb:00bb` | - | No known fix | [gap-map](unsupported-devices.md) |
+| HP Zbook 15 G2 / HP Probook 430 | `138a:003f` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Asus
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| ASUS Vivobook f571gt- al318t | `04f3:3104` | lead: partial | No known fix | [gap-map](unsupported-devices.md) |
+| Asus Vivobook K6500zc | `2808:a658` | - | No known fix | [gap-map](unsupported-devices.md) |
+| ASUS VivoBook Pro 15 N580GD | `04f3:3057` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Asus Zenbook Pro UX580 | `04f3:2706` | - | No known fix | [gap-map](unsupported-devices.md) |
+| ASUS ZenBook S UX391FA-AH001T | `27c6:5201` | - | No known fix | [gap-map](unsupported-devices.md) |
+| ASUS ZenBook UX330CA | `04f3:3032` | - | No known fix | [gap-map](unsupported-devices.md) |
+| ELAN:ARM-M4 ASUS Vivobook | `04f3:0c90` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Focaltech FT9365, Asus VivoBook | `2808:a553` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Acer
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| Acer ConceptD CC314-72 | `06cb:00e4` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Acer Spin 3, SP313-51N | `06cb:00dc` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Acer Swift 1 (SF114-32-P78E)? | `1c7a:0300` | lead: RE effort exists | No known fix | [gap-map](unsupported-devices.md) |
+| Acer Swift 3 | `04f3:0c7f` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Acer Swift 3 OLED (SF314-71-56U3) | `10a5:e340` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Acer Swift 3 SF314-43 | `04f3:0c72` | - | No known fix | [gap-map](unsupported-devices.md) |
+| ELAN:ARM-M4 ACER Aspire Vero | `04f3:0c85` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Samsung
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| Samsung Galaxy Book 4 | `2808:6553` | FocalTech FT9365 ESS (focaltech_moc) | Merged upstream | [entry](../devices/2808:6553/) |
+| Samsung GalaxyBook Pro 360 | `1c7a:057e` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Huawei
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| MagicBook 2019 R7 / Huawei Matebook 13 2020 | `27c6:5117` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Matebook D16 | `27c6:5120` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Honor
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| HONOR HYM-WXX MagicBook 16 | `27c6:5125` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Honor Magicbook Art 14 | `27c6:5f91` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Honor Magicbook x16 plus 2024 | `10a5:a921` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Honor MagicBook X16Pro Ryzen 7 7840HS | `27c6:5f10` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Xiaomi / Redmi
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| Xiaomi RedmiBook 14 Pro | `10a5:9201` | FPC Sensor Controller L:0001 - fingerprint-ocv | Working (vendor blob) | [entry](../devices/10a5:9201/) |
+| Mi RedmiBook 15 2022 Pro | `27c6:589a` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Mi RedmiBook Pro | `27c6:581a` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Redmi Book Pro, 14" AMD | `04f3:0c70` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Microsoft Surface
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| ELAN:ARM-M4 - Surface Laptop Go 2 | `04f3:0c80` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Surface Laptop Go | `04f3:0c5a` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## MSI
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| MSI Prestige 14 A10RB | `06cb:009b` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## LG
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| LG GRAM 2018 | `10a5:0007` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Handhelds and mini PCs
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| AYANEO 2 | `2541:0236` | Chipsailing CS9711 | Working (vendor blob) | [entry](../devices/2541:0236/) |
+| GPD Win Max 2 | `2541:0236` | Chipsailing CS9711 | Working (vendor blob) | [entry](../devices/2541:0236/) |
+| GTR5 mini | `1c7a:0577` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Other vendors
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| CanvasBio CB2000 | `2df0:0003` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Clevo Laptops | `06cb:00a8` | - | No known fix | [gap-map](unsupported-devices.md) |
+| realme book MP | `27c6:5e0a` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Teclast F6 Pro | `27c6:5740` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Toshiba B2B-range X30-D and X40-D | `06cb:008a` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+## Other and unidentified
+
+Rows the upstream wiki records against a chip or module name
+rather than a machine. Match these on the USB ID.
+
+| Laptop model | USB ID | Sensor | Status | Where to go |
+|--------------|--------|--------|--------|-------------|
+| Broadcom Corp. 58200 | `0a5c:5864` | - | No known fix | [gap-map](unsupported-devices.md) |
+| DigitalPersona 5300 | `05ba:000e` | - | No known fix | [gap-map](unsupported-devices.md) |
+| ELAN/FA461D-2203 | `04f3:3128` | - | No known fix | [gap-map](unsupported-devices.md) |
+| External, Validity90 project is relevant | `06cb:0088` | - | No known fix | [gap-map](unsupported-devices.md) |
+| magikbook 14x | `10a5:a900` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Validity90 | `06cb:00a1` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Validity90 | `06cb:00a2` | - | No known fix | [gap-map](unsupported-devices.md) |
+
+---
+
+_Generated by `tools/gen-laptop-index.py`. Do not edit by hand: edit a
+`devices/<id>/MODELS` file or the gap-map and regenerate._

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Render the repo's markdown into a static site for GitHub Pages.
+
+    pip install markdown
+    python3 tools/build-site.py [--out site] [--base-url /linux-fingerprint-drivers]
+
+Why this exists: essentially everyone who reaches this repo arrives from a
+search engine having typed a laptop model or a USB ID, and GitHub's own blob
+pages index poorly. One real HTML page per sensor, with a title and description
+naming the ID, the chip and the machines it ships in, is the difference between
+being findable and not.
+
+The site is generated, never committed. Every page is built from the same
+markdown that GitHub renders, so there is only one copy of the content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import quote, urlparse
+
+REPO = Path(__file__).resolve().parent.parent
+GITHUB = "https://github.com/jedbillyb/linux-fingerprint-drivers"
+GITHUB_BLOB = GITHUB + "/blob/master/"
+GITHUB_TREE = GITHUB + "/tree/master/"
+
+USB_ID = re.compile(r"^[0-9a-f]{4}:[0-9a-f]{4}$")
+TITLE = re.compile(r"^#\s+(.+?)\s*$", re.M)
+STATUS = re.compile(r"^\*\*Status:\s*(.+?)\*\*\s*$", re.M | re.I)
+MD_LINK = re.compile(r"(?<!\!)\[([^\]]*)\]\(([^)\s]+)(\s+\"[^\"]*\")?\)")
+FIRST_PROSE = re.compile(r"^(?![#>|\-*`])\S.*$", re.M)
+
+
+@dataclass
+class Page:
+    """One rendered HTML page and everything the templates need about it."""
+    source: Path                  # repo-relative markdown path
+    url_path: str                 # site path, no leading or trailing slash
+    title: str                    # <title>
+    heading: str                  # visible h1 (comes from the markdown itself)
+    description: str
+    markdown: str
+    models: list[str] = field(default_factory=list)
+    usb_ids: list[str] = field(default_factory=list)
+    priority: str = "0.5"
+
+
+def slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def squash(text: str) -> str:
+    """Markdown prose to a single clean line for a meta description."""
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = MD_LINK.sub(r"\1", text)
+    text = re.sub(r"\*\*([^*]*)\*\*", r"\1", text)
+    text = re.sub(r"[*_>]", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def clip(text: str, limit: int = 158) -> str:
+    text = squash(text)
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rsplit(" ", 1)[0]
+    return cut.rstrip(" .,;:") + "..."
+
+
+def sensor_name(title: str) -> str:
+    return re.sub(r"\s*\((?:USB|PID)[^)]*\)\s*$", "", title).strip()
+
+
+def read_models(entry: Path) -> list[str]:
+    f = entry / "MODELS"
+    if not f.is_file():
+        return []
+    return [ln.strip() for ln in f.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.startswith("#")]
+
+
+def collect_pages() -> list[Page]:
+    pages: list[Page] = []
+
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    pages.append(Page(
+        source=Path("README.md"),
+        url_path="",
+        title="Linux fingerprint reader drivers: sensors libfprint does not support",
+        heading="linux-fingerprint-drivers",
+        description=(
+            "Community catalogue of drivers, patches and setup notes for fingerprint "
+            "readers that upstream libfprint does not support. Find your sensor by "
+            "USB ID or laptop model."
+        ),
+        markdown=readme,
+        priority="1.0",
+    ))
+
+    contributing = REPO / "CONTRIBUTING.md"
+    if contributing.is_file():
+        text = contributing.read_text(encoding="utf-8")
+        pages.append(Page(
+            source=Path("CONTRIBUTING.md"),
+            url_path="contributing",
+            title="Contributing a fingerprint sensor entry or report",
+            heading=heading_of(text, "Contributing"),
+            description=clip(first_prose(text)),
+            markdown=text,
+            priority="0.3",
+        ))
+
+    for doc in sorted((REPO / "docs").glob("*.md")):
+        text = doc.read_text(encoding="utf-8")
+        name = doc.stem
+        head = heading_of(text, name)
+        if name == "laptops":
+            title = "Fingerprint reader support on Linux by laptop model"
+            desc = ("Which laptops have fingerprint readers that work on Linux, indexed "
+                    "by model: ThinkPad, XPS, EliteBook, ProBook, Latitude, MagicBook "
+                    "and more, with the USB ID and driver route for each.")
+            priority = "0.9"
+        elif name == "unsupported-devices":
+            title = "Fingerprint sensors with no Linux driver (contributor gap-map)"
+            desc = clip(first_prose(text))
+            priority = "0.6"
+        elif name == "BUILD":
+            title = "Building libfprint from source for an unsupported fingerprint reader"
+            desc = ("Build, install, PAM setup, package pinning, troubleshooting and "
+                    "revert steps for running a patched libfprint on Arch, Fedora, "
+                    "Debian and Ubuntu.")
+            priority = "0.7"
+        else:
+            title = head
+            desc = clip(first_prose(text))
+            priority = "0.5"
+        pages.append(Page(
+            source=Path("docs") / doc.name,
+            url_path=f"docs/{slug(name)}",
+            title=title,
+            heading=head,
+            description=desc,
+            markdown=text,
+            priority=priority,
+        ))
+
+    for entry in sorted(p for p in (REPO / "devices").iterdir() if p.is_dir()):
+        md = entry / "README.md"
+        if not md.is_file():
+            continue
+        text = md.read_text(encoding="utf-8")
+        head = heading_of(text, entry.name)
+        chip = sensor_name(head)
+        models = read_models(entry)
+        ids = sorted(set(re.findall(r"\b[0-9a-f]{4}:[0-9a-f]{4}\b", head)))
+        if USB_ID.match(entry.name) and entry.name not in ids:
+            ids.insert(0, entry.name)
+
+        if USB_ID.match(entry.name):
+            title = f"{entry.name} fingerprint reader on Linux: {chip}"
+        else:
+            title = f"{chip}: fingerprint reader support on Linux"
+        if models:
+            title += " (" + ", ".join(models[:2]) + ")"
+
+        status = STATUS.search(text)
+        bits = []
+        if status:
+            bits.append(squash(status.group(1)).rstrip("."))
+        if models:
+            bits.append("Seen on " + ", ".join(models[:4]))
+        bits.append(clip(first_prose(text), 90))
+        pages.append(Page(
+            source=Path("devices") / entry.name / "README.md",
+            url_path=f"devices/{slug(entry.name)}",
+            title=title,
+            heading=head,
+            description=clip(". ".join(b for b in bits if b)),
+            markdown=text,
+            models=models,
+            usb_ids=ids,
+            priority="0.8",
+        ))
+
+    return pages
+
+
+def heading_of(text: str, fallback: str) -> str:
+    m = TITLE.search(text)
+    return m.group(1).strip() if m else fallback
+
+
+def first_prose(text: str) -> str:
+    body = TITLE.sub("", text, count=1)
+    for line in FIRST_PROSE.finditer(body):
+        candidate = line.group(0).strip()
+        if len(candidate) > 40:
+            # Grab the rest of that paragraph so the description is a sentence.
+            rest = body[line.start():].split("\n\n", 1)[0]
+            return rest
+    return squash(body)[:200]
+
+
+def build_link_map(pages: list[Page]) -> dict[str, str]:
+    """Repo-relative source path -> site path, plus the directory forms of it."""
+    out: dict[str, str] = {}
+    for page in pages:
+        src = page.source.as_posix()
+        out[src] = page.url_path
+        if src.endswith("/README.md"):
+            out[src[: -len("README.md")]] = page.url_path       # 'devices/x/'
+            out[src[: -len("/README.md")]] = page.url_path      # 'devices/x'
+        elif src == "README.md":
+            out["."] = page.url_path
+    return out
+
+
+def rewrite_links(page: Page, link_map: dict[str, str], base: str) -> str:
+    """Point internal markdown links at the built site, everything else at GitHub."""
+    src_dir = page.source.parent
+
+    def resolve(target: str) -> str:
+        if not target or target.startswith("#"):
+            return target
+        parsed = urlparse(target)
+        if parsed.scheme or target.startswith("//") or target.startswith("mailto:"):
+            return target
+
+        path, _, anchor = target.partition("#")
+        anchor = f"#{anchor}" if anchor else ""
+        if not path:
+            return target
+
+        try:
+            resolved = (src_dir / path).resolve().relative_to(REPO).as_posix()
+        except (ValueError, OSError):
+            return target
+        trailing = "/" if path.endswith("/") else ""
+
+        for key in (resolved + trailing, resolved, resolved + "/"):
+            if key in link_map:
+                dest = link_map[key]
+                return f"{base}/{dest}/{anchor}" if dest else f"{base}/{anchor}"
+
+        # Not a rendered page: a patch, a CREDITS file, a directory of them.
+        abs_path = REPO / resolved
+        prefix = GITHUB_TREE if abs_path.is_dir() else GITHUB_BLOB
+        return prefix + quote(resolved) + anchor
+
+    def sub(m: re.Match[str]) -> str:
+        return f"[{m.group(1)}]({resolve(m.group(2))}{m.group(3) or ''})"
+
+    return MD_LINK.sub(sub, page.markdown)
+
+
+STYLE = """
+:root{--bg:#fff;--fg:#1c1e21;--muted:#5b616b;--line:#d8dce1;--accent:#0b5fd0;
+--code-bg:#f4f6f8;--card:#f8f9fb;--ok:#1a7f4b;--warn:#8a5a00;--bad:#a32020}
+@media (prefers-color-scheme:dark){:root{--bg:#0f1115;--fg:#e6e8ec;--muted:#9aa3ad;
+--line:#2a2f37;--accent:#6aa8ff;--code-bg:#161a20;--card:#141821;--ok:#4cc38a;
+--warn:#d9a441;--bad:#f2777a}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+.wrap{max-width:52rem;margin:0 auto;padding:1.25rem 1.15rem 4rem}
+header.site{border-bottom:1px solid var(--line);margin-bottom:1.75rem}
+header.site .wrap{padding-bottom:.85rem;padding-top:.85rem}
+nav a{margin-right:1rem;white-space:nowrap}
+nav{display:flex;flex-wrap:wrap;gap:.15rem .25rem;font-size:.94rem}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+h1{font-size:1.75rem;line-height:1.25;margin:0 0 .6rem}
+h2{font-size:1.3rem;margin:2.2rem 0 .7rem;padding-top:.3rem;border-top:1px solid var(--line)}
+h3{font-size:1.08rem;margin:1.6rem 0 .5rem}
+code{background:var(--code-bg);padding:.12em .34em;border-radius:4px;
+font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.9em}
+pre{background:var(--code-bg);padding:.85rem 1rem;border-radius:8px;overflow-x:auto;
+border:1px solid var(--line)}
+pre code{background:none;padding:0;font-size:.86rem}
+.table-wrap{overflow-x:auto;margin:1rem 0}
+table{border-collapse:collapse;width:100%;font-size:.92rem}
+th,td{border:1px solid var(--line);padding:.45rem .6rem;text-align:left;vertical-align:top}
+th{background:var(--card);font-weight:600}
+blockquote{margin:1rem 0;padding:.1rem 1rem;border-left:3px solid var(--line);color:var(--muted)}
+.meta{background:var(--card);border:1px solid var(--line);border-radius:8px;
+padding:.85rem 1rem;margin:0 0 1.5rem;font-size:.94rem}
+.meta dl{display:grid;grid-template-columns:auto 1fr;gap:.35rem .9rem;margin:0}
+.meta dt{color:var(--muted);font-weight:600}
+.meta dd{margin:0}
+footer.site{border-top:1px solid var(--line);margin-top:3rem;padding-top:1rem;
+color:var(--muted);font-size:.88rem}
+.breadcrumb{color:var(--muted);font-size:.88rem;margin-bottom:.5rem}
+img{max-width:100%}
+"""
+
+
+def nav_html(base: str) -> str:
+    items = [
+        ("Home", f"{base}/"),
+        ("Find your laptop", f"{base}/docs/laptops/"),
+        ("Build guide", f"{base}/docs/build/"),
+        ("Gap-map", f"{base}/docs/unsupported-devices/"),
+        ("Contributing", f"{base}/contributing/"),
+        ("GitHub", GITHUB),
+    ]
+    return "".join(f'<a href="{html.escape(u)}">{html.escape(t)}</a>' for t, u in items)
+
+
+def meta_block(page: Page, base: str) -> str:
+    """The at-a-glance box on a device page: IDs, machines, source file."""
+    if not page.source.parts[:1] == ("devices",):
+        return ""
+    rows = []
+    if page.usb_ids:
+        rows.append(("USB ID", ", ".join(f"<code>{html.escape(i)}</code>"
+                                         for i in page.usb_ids)))
+    if page.models:
+        rows.append(("Reported in", html.escape(", ".join(page.models))))
+    rows.append((
+        "Source",
+        f'<a href="{GITHUB_BLOB}{quote(page.source.as_posix())}">'
+        f'{html.escape(page.source.as_posix())}</a>',
+    ))
+    body = "".join(f"<dt>{k}</dt><dd>{v}</dd>" for k, v in rows)
+    return f'<div class="meta"><dl>{body}</dl></div>'
+
+
+def render_page(page: Page, body_html: str, base: str, site_url: str) -> str:
+    canonical = f"{site_url}/{page.url_path}/" if page.url_path else f"{site_url}/"
+    crumb = ""
+    if page.url_path:
+        crumb = (f'<div class="breadcrumb"><a href="{base}/">'
+                 f"linux-fingerprint-drivers</a> / {html.escape(page.heading)}</div>")
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{html.escape(page.title)}</title>
+<meta name="description" content="{html.escape(page.description)}">
+<link rel="canonical" href="{html.escape(canonical)}">
+<meta property="og:type" content="article">
+<meta property="og:title" content="{html.escape(page.title)}">
+<meta property="og:description" content="{html.escape(page.description)}">
+<meta property="og:url" content="{html.escape(canonical)}">
+<meta name="twitter:card" content="summary">
+<style>{STYLE}</style>
+</head>
+<body>
+<header class="site"><div class="wrap"><nav>{nav_html(base)}</nav></div></header>
+<main class="wrap">
+{crumb}
+{meta_block(page, base)}
+{body_html}
+</main>
+<footer class="site"><div class="wrap">
+Community catalogue of Linux fingerprint reader drivers.
+Content mirrors <a href="{GITHUB}">the repository</a>; hosted code is LGPL-2.1.
+Always check <a href="https://fprint.freedesktop.org/supported-devices.html">upstream
+libfprint</a> first.
+</div></footer>
+</body>
+</html>
+"""
+
+
+def wrap_tables(body: str) -> str:
+    """Tables must scroll inside themselves, not push the page sideways."""
+    return body.replace("<table>", '<div class="table-wrap"><table>') \
+               .replace("</table>", "</table></div>")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="site")
+    ap.add_argument("--base-url", default="/linux-fingerprint-drivers")
+    ap.add_argument("--site-url", default="https://jedbillyb.github.io/linux-fingerprint-drivers")
+    args = ap.parse_args()
+
+    try:
+        import markdown
+    except ImportError:
+        print("this needs the 'markdown' package: pip install markdown", file=sys.stderr)
+        return 1
+
+    base = args.base_url.rstrip("/")
+    site_url = args.site_url.rstrip("/")
+    out = (REPO / args.out) if not Path(args.out).is_absolute() else Path(args.out)
+    if out.exists():
+        shutil.rmtree(out)
+
+    pages = collect_pages()
+    link_map = build_link_map(pages)
+    md = markdown.Markdown(extensions=["tables", "fenced_code", "toc", "sane_lists"])
+
+    for page in pages:
+        md.reset()
+        body = wrap_tables(md.convert(rewrite_links(page, link_map, base)))
+        target = out / page.url_path / "index.html" if page.url_path else out / "index.html"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(render_page(page, body, base, site_url), encoding="utf-8")
+
+    urls = "".join(
+        "<url><loc>{}</loc><priority>{}</priority></url>".format(
+            f"{site_url}/{p.url_path}/" if p.url_path else f"{site_url}/", p.priority)
+        for p in pages
+    )
+    (out / "sitemap.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        f"{urls}</urlset>\n",
+        encoding="utf-8",
+    )
+    (out / "robots.txt").write_text(
+        f"User-agent: *\nAllow: /\nSitemap: {site_url}/sitemap.xml\n", encoding="utf-8")
+    # Jekyll would otherwise eat directories it considers special.
+    (out / ".nojekyll").write_text("", encoding="utf-8")
+
+    print(f"built {len(pages)} pages into {out.relative_to(REPO) if out.is_relative_to(REPO) else out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-repo.py
+++ b/tools/check-repo.py
@@ -148,6 +148,41 @@ def check_no_contradictions(readme: str) -> None:
         fail("README.md", "does not link to docs/unsupported-devices.md")
 
 
+def check_models() -> None:
+    """MODELS files feed docs/laptops.md and the per-page titles on the site.
+
+    They are optional (plenty of sensors have no reported machine yet), but a
+    malformed one silently distorts the laptop index, so the format is checked.
+    """
+    for entry in sorted(p for p in DEVICES.iterdir() if p.is_dir()):
+        models = entry / "MODELS"
+        if not models.is_file():
+            continue
+        lines = [ln.rstrip() for ln in models.read_text().splitlines()]
+        useful = [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
+        if not useful:
+            fail(models, "exists but lists no models; delete it instead")
+        if len(useful) != len(set(useful)):
+            fail(models, "lists the same model twice")
+        for line in useful:
+            if len(line) > 80:
+                fail(models, f"model name looks like prose, not a model: {line[:50]}...")
+            if line.startswith(("-", "*", "|")):
+                fail(models, f"one plain model per line, no list markup: {line[:50]}")
+
+
+def check_laptop_index() -> None:
+    index = REPO / "docs" / "laptops.md"
+    if not index.is_file():
+        fail("docs/laptops.md", "missing; run python3 tools/gen-laptop-index.py")
+        return
+    if "gen-laptop-index.py" not in index.read_text():
+        fail(
+            "docs/laptops.md",
+            "is missing its generated-file marker; it must not be hand-edited",
+        )
+
+
 def check_tools_executable() -> None:
     for script in sorted((REPO / "tools").glob("*.sh")):
         if not script.stat().st_mode & 0o111:
@@ -164,6 +199,8 @@ def main() -> int:
     check_device_entries(readme)
     check_links()
     check_no_contradictions(readme)
+    check_models()
+    check_laptop_index()
     check_tools_executable()
 
     entry_count = len([p for p in DEVICES.iterdir() if p.is_dir()])

--- a/tools/gen-laptop-index.py
+++ b/tools/gen-laptop-index.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Generate docs/laptops.md, the by-laptop-model index.
+
+    python3 tools/gen-laptop-index.py            # rewrite docs/laptops.md
+    python3 tools/gen-laptop-index.py --check    # fail if it is out of date
+
+Most people arrive knowing their laptop, not their USB ID. This builds a model
+-> USB ID -> entry index from two sources that already exist in the repo, so it
+cannot drift from them:
+
+  * devices/<id>/MODELS  - one laptop model per line, for catalogued sensors
+  * docs/unsupported-devices.md - the gap-map's Hardware column
+
+Nothing here is hand-written, so a new MODELS line is all it takes to appear.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEVICES = REPO / "devices"
+GAP_MAP = REPO / "docs" / "unsupported-devices.md"
+OUT = REPO / "docs" / "laptops.md"
+
+# Row order within the page: the statuses people can act on come first.
+STATUS_ORDER = {
+    "Working": 0,
+    "Working (vendor blob)": 1,
+    "Partial": 2,
+    "Merged upstream": 3,
+    "WIP": 4,
+    "Unreliable": 5,
+    "Stale": 6,
+    "No known fix": 7,
+}
+
+# Matched against the whole model string, first hit wins, so put the
+# distinctive product lines before the bare vendor names.
+VENDORS: list[tuple[str, tuple[str, ...]]] = [
+    ("Lenovo", ("thinkpad", "thinkbook", "ideapad", "legion", "yoga", "lenovo")),
+    ("Dell", ("xps", "latitude", "precision", "inspiron", "vostro", "alienware", "dell")),
+    ("HP", ("elitebook", "probook", "zbook", "pavilion", "envy", "spectre", "omen",
+            "victus", "hp ", "hp-")),
+    ("Asus", ("zenbook", "vivobook", "expertbook", "rog ", "tuf ", "asus")),
+    ("Acer", ("aspire", "swift", "nitro", "predator", "travelmate", "acer")),
+    ("Samsung", ("galaxy book", "samsung")),
+    ("Huawei", ("matebook", "huawei")),
+    ("Honor", ("magicbook", "honor")),
+    ("Xiaomi / Redmi", ("redmibook", "redmi", "xiaomi", "mi notebook", "mi ")),
+    ("Framework", ("framework",)),
+    ("Microsoft Surface", ("surface",)),
+    ("MSI", ("katana", "modern", "prestige", "msi")),
+    ("LG", ("lg gram", "gram ")),
+    ("Handhelds and mini PCs", ("gpd win", "ayaneo", "gtr5", "steam deck", "onexplayer")),
+    ("Chromebooks", ("chromebook",)),
+    ("Other vendors", ("realme", "canvasbio", "tuxedo", "system76", "clevo", "medion",
+                       "fujitsu", "toshiba", "panasonic", "gigabyte", "razer",
+                       "teclast", "chuwi", "vaio", "dynabook")),
+]
+
+# Gap-map Hardware cells that name no machine, or name a peripheral rather
+# than a laptop (the upstream wiki has a few of both).
+PLACEHOLDER = re.compile(r"^(-|n/?a|external(\s*\(usb\))?|unknown|\?)$", re.I)
+NOT_A_LAPTOP = re.compile(r"\b(mouse|keyboard|dongle|hub)\b", re.I)
+
+# The gap-map writes an ID either as a wiki link or as bare code, depending on
+# whether that device has a wiki page that actually exists, so accept both:
+#   | [04f3:0c57](https://.../04f3:0c57) | Lenovo IdeaPad 3-15ARE05 |  |
+#   | `04f3:0c5a`                        | Surface Laptop Go        |  |
+GAP_ROW = re.compile(
+    r"^\|\s*[`\[]?([0-9a-f]{4}:[0-9a-f]{4})[`\]]?[^|]*\|\s*([^|]*?)\s*\|\s*([^|]*?)\s*\|\s*$"
+)
+TITLE = re.compile(r"^#\s+(.+?)\s*$", re.M)
+STATUS = re.compile(r"^\*\*Status:\s*(.+?)\*\*\s*$", re.M | re.I)
+
+
+def classify(status_text: str) -> str:
+    """Collapse each entry's prose status line into one comparable word."""
+    low = status_text.lower()
+    if low.startswith("merged"):
+        return "Merged upstream"
+    if low.startswith("stale"):
+        return "Stale"
+    if low.startswith("partial"):
+        return "Partial"
+    if low.startswith("claimed"):
+        return "Unreliable"
+    if low.startswith("wip"):
+        return "WIP"
+    if low.startswith(("working", "works")):
+        # A vendor blob route works, but it is not the same offer as open code.
+        if "proprietary" in low or "vendor" in low or "agpl" in low:
+            return "Working (vendor blob)"
+        return "Working"
+    return "WIP"
+
+
+def vendor_of(model: str) -> str:
+    low = model.lower()
+    for name, keys in VENDORS:
+        if any(k in low for k in keys):
+            return name
+    return "Other and unidentified"
+
+
+def sensor_name(title: str) -> str:
+    """Strip the '(USB ....)' tail from an entry title to get the chip name."""
+    return re.sub(r"\s*\((?:USB|PID)[^)]*\)\s*$", "", title).strip()
+
+
+def read_entries() -> list[dict]:
+    rows: list[dict] = []
+    for entry in sorted(p for p in DEVICES.iterdir() if p.is_dir()):
+        models_file = entry / "MODELS"
+        if not models_file.is_file():
+            continue
+        readme = (entry / "README.md").read_text(encoding="utf-8")
+        title = TITLE.search(readme)
+        status = STATUS.search(readme)
+        if not title or not status:
+            print(f"warning: {entry.name} has no title or status line", file=sys.stderr)
+            continue
+        sensor = sensor_name(title.group(1))
+        state = classify(status.group(1))
+        for line in models_file.read_text(encoding="utf-8").splitlines():
+            model = line.strip()
+            if not model or model.startswith("#"):
+                continue
+            rows.append({
+                "model": model,
+                "id": entry.name,
+                "sensor": sensor,
+                "status": state,
+                "link": f"../devices/{entry.name}/",
+            })
+    return rows
+
+
+def read_gap_map() -> list[dict]:
+    rows: list[dict] = []
+    for line in GAP_MAP.read_text(encoding="utf-8").splitlines():
+        m = GAP_ROW.match(line)
+        if not m:
+            continue
+        usb_id, hardware, lead = m.group(1), m.group(2).strip(), m.group(3).strip()
+        if not hardware or PLACEHOLDER.match(hardware) or NOT_A_LAPTOP.search(hardware):
+            continue
+        rows.append({
+            "model": hardware,
+            "id": usb_id,
+            "sensor": "lead: " + lead if lead else "",
+            "status": "No known fix",
+            "link": "unsupported-devices.md",
+        })
+    return rows
+
+
+def render(rows: list[dict]) -> str:
+    covered = sum(1 for r in rows if r["status"] != "No known fix")
+    out: list[str] = []
+    add = out.append
+
+    add("# Find your laptop")
+    add("")
+    add("Fingerprint reader support on Linux, indexed by **laptop model** rather")
+    add("than by USB ID. If `fprintd-enroll` fails on your machine, find it below.")
+    add("")
+    add("This page is generated from the device entries and the")
+    add("[gap-map](unsupported-devices.md); it lists every model those name, and")
+    add("nothing else. Absence from this page is not evidence that a reader works")
+    add("or does not: it usually just means nobody has reported that model yet.")
+    add("Many sensors also ship in machines nobody has written down here, so if")
+    add("your exact model is missing, **match on the USB ID instead**:")
+    add("")
+    add("```sh")
+    add("lsusb        # find the reader, e.g. 27c6:55b4")
+    add("```")
+    add("")
+    add("then look it up in the [main README](../README.md), or run")
+    add("`./tools/detect.sh` to have it matched for you.")
+    add("")
+    add(f"{covered} model listings map to a catalogued sensor; the rest are on the")
+    add("gap-map with no known fix, and a protocol dump for any of them is welcome.")
+    add("")
+    add("**Adding your machine** is the single most useful small contribution here.")
+    add("Open a [device report](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/new?template=device-report.yml)")
+    add("with your model and `lsusb` line, or add a line to the sensor's")
+    add("`devices/<id>/MODELS` file and open a PR.")
+    add("")
+    add("Status legend: **Working** (enroll and verify reliable), **Working (vendor")
+    add("blob)** (only via a proprietary driver, see the entry's caveats),")
+    add("**Partial**, **Merged upstream** (in libfprint git, build from source),")
+    add("**WIP** (unmerged work exists), **Unreliable** (claimed upstream but fails")
+    add("in practice), **Stale** (abandoned lead), **No known fix**.")
+    add("")
+
+    groups: dict[str, list[dict]] = {}
+    for row in rows:
+        groups.setdefault(vendor_of(row["model"]), []).append(row)
+
+    order = [name for name, _ in VENDORS] + ["Other and unidentified"]
+    for vendor in order:
+        items = groups.get(vendor)
+        if not items:
+            continue
+        items.sort(key=lambda r: (STATUS_ORDER[r["status"]], r["model"].lower()))
+        add(f"## {vendor}")
+        add("")
+        if vendor == "Other and unidentified":
+            add("Rows the upstream wiki records against a chip or module name")
+            add("rather than a machine. Match these on the USB ID.")
+            add("")
+        add("| Laptop model | USB ID | Sensor | Status | Where to go |")
+        add("|--------------|--------|--------|--------|-------------|")
+        for r in items:
+            sensor = r["sensor"] or "-"
+            where = "[entry](%s)" % r["link"] if r["status"] != "No known fix" \
+                else "[gap-map](unsupported-devices.md)"
+            add(f"| {r['model']} | `{r['id']}` | {sensor} | {r['status']} | {where} |")
+        add("")
+
+    add("---")
+    add("")
+    add("_Generated by `tools/gen-laptop-index.py`. Do not edit by hand: edit a")
+    add("`devices/<id>/MODELS` file or the gap-map and regenerate._")
+    add("")
+    return "\n".join(out)
+
+
+def main() -> int:
+    rows = read_entries() + read_gap_map()
+    if not rows:
+        print("no models found; is devices/*/MODELS missing?", file=sys.stderr)
+        return 1
+    text = render(rows)
+
+    if "--check" in sys.argv:
+        current = OUT.read_text(encoding="utf-8") if OUT.is_file() else ""
+        if current != text:
+            print(
+                "docs/laptops.md is out of date; run: python3 tools/gen-laptop-index.py",
+                file=sys.stderr,
+            )
+            # Show what differs, so a CI failure is diagnosable from the log
+            # rather than only reproducible by rerunning the generator.
+            diff = difflib.unified_diff(
+                current.splitlines(keepends=True),
+                text.splitlines(keepends=True),
+                fromfile="docs/laptops.md (committed)",
+                tofile="docs/laptops.md (regenerated)",
+                n=1,
+            )
+            sys.stderr.writelines(list(diff)[:80])
+            return 1
+        return 0
+
+    OUT.write_text(text, encoding="utf-8")
+    print(f"wrote {OUT.relative_to(REPO)} ({len(rows)} model listings)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
All inbound traffic to this repo is search-driven (Google, DuckDuckGo, ChatGPT referrers), it lands on the front page, and it stops there. This addresses the two things standing in the way of that.

## People search their laptop, not their USB ID

`docs/laptops.md` is a new model -> USB ID -> entry index, generated from two sources the repo already has:

- `devices/<id>/MODELS`, a new optional one-model-per-line file (14 entries seeded from models already stated in the entry prose)
- the gap-map's Hardware column, which already named ~90 machines

101 model listings, no hand-written data, grouped by vendor and sorted so actionable statuses come first. `tools/gen-laptop-index.py --check` runs in CI so it cannot drift from its sources.

## GitHub blob pages index poorly

`tools/build-site.py` renders the same markdown into one HTML page per sensor, with:

- a title naming the USB ID, the chip and the machines it ships in
- a meta description built from the status line, the models and the opening prose
- canonical URLs, Open Graph tags, a sitemap and robots.txt
- an at-a-glance box on each device page listing IDs and reported machines

The site is generated and gitignored, never committed, so there is still exactly one copy of the content. 46 pages, verified with zero dead internal links.

## Also

- `MODELS` documented in CONTRIBUTING, with the "only list machines somebody has actually seen" rule
- the device-report form now explains what the Hardware field is used for
- `tools/check-repo.py` validates MODELS formatting and that laptops.md is not hand-edited
- CI gains a laptop-index freshness check and a site build

## Before merging

GitHub Pages is enabled with the Actions build source. The `pages` workflow only fires on push to master, so the first deploy to <https://jedbillyb.github.io/linux-fingerprint-drivers/> happens when this merges.

Repo topics were also expanded from 6 to 15 to cover the vendor names people actually search (goodix, synaptics, elan, validity, thinkpad, biometrics, fingerprint-reader, hardware-support, linux-hardware).