### PR TITLE
Move the site to fprint.jedbillyb.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If your sensor shows up in `lsusb` but `fprintd-enroll` fails or the device is
 unknown to libfprint, there may be a working fix here, or you can contribute one.
 
 Browsable as a website, one page per sensor:
-**<https://fingerprint.jedbillyb.com>**
+**<https://fprint.jedbillyb.com>**
 
 **Check upstream first:** if your reader is on libfprint's own
 [supported devices](https://fprint.freedesktop.org/supported-devices.html) list,

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -399,8 +399,8 @@ def main() -> int:
     # Served from its own hostname, so pages sit at the root rather than under
     # a /linux-fingerprint-drivers/ path prefix.
     ap.add_argument("--base-url", default="")
-    ap.add_argument("--site-url", default="https://fingerprint.jedbillyb.com")
-    ap.add_argument("--cname", default="fingerprint.jedbillyb.com",
+    ap.add_argument("--site-url", default="https://fprint.jedbillyb.com")
+    ap.add_argument("--cname", default="fprint.jedbillyb.com",
                     help="custom domain written to site/CNAME; empty to omit")
     args = ap.parse_args()
 


### PR DESCRIPTION
Renames the site hostname before any external links exist to freeze it. Updates the canonical URLs, sitemap, CNAME and README.