### PR TITLE
Add Goodix GXFP5187 (SPI) — Huawei MateBook X Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ appear in `lsusb` at all.
 | 2541:0236 (9711)     | Chipsailing CS9711      | Working | Arch (GPD Win Max 2, AYANEO 2) |
 | 06cb:00ff (+00c9/00d1/00e7/0124/0169) | Synaptics Tudor MiS | Working | Arch, Fedora, Ubuntu (community routes) |
 | 2808:9e65            | FocalTech               | Partial | Undocumented (unconfirmed)  |
+| gxfp5187 (SPI)       | Goodix GXFP5187         | Working | Ubuntu 24.04 ([entry](devices/gxfp5187/)) |
 
 Status legend: **Working** (enroll + verify reliable), **Partial** (works with
 caveats), **WIP** (in progress). Statuses only move when someone reports back,

--- a/devices/gxfp5187/CREDITS
+++ b/devices/gxfp5187/CREDITS
@@ -1,0 +1,23 @@
+Driver and protocol reverse-engineering:
+  Benjamin Allègre (@Sigfrodr)
+  https://github.com/Sigfrodr/libfprint-goodixtls
+  Base: commit d7ed1db (branch main), against libfprint-2-tod1 1.94.7+tod1.
+
+Reference work this build relied on:
+  JJJollyjim — wireshark-goodix: Wireshark dissector for the GXFP5187 SPI
+    protocol, with a sample SPI capture. The key protocol reference.
+    https://github.com/JJJollyjim/wireshark-goodix
+  PeshalaDilshan — OpenGoodixSPI: experimental kernel driver for Goodix SPI
+    sensors, GXFP5187 referenced.
+    https://github.com/PeshalaDilshan/OpenGoodixSPI
+  lexakimov — goodix51c0_spi-reversing: Goodix 51C0 SPI protocol RE.
+    https://github.com/lexakimov/goodix51c0_spi-reversing
+  goodix-fp-linux-dev — goodix-fp-dump: Goodix USB protocol work, useful for
+    comparison. https://github.com/goodix-fp-linux-dev/goodix-fp-dump
+  archshift — goodix_fingerprint_re: Goodix driver RE (Dell XPS 15 2019).
+    https://github.com/archshift/goodix_fingerprint_re
+
+Matcher technique references:
+  D. Lowe, "Distinctive Image Features from Scale-Invariant Keypoints" (2004).
+  Arandjelović & Zisserman, "Three things everyone should know to improve
+    object retrieval" — RootSIFT (2012).

--- a/devices/gxfp5187/MODELS
+++ b/devices/gxfp5187/MODELS
@@ -1,0 +1,1 @@
+Huawei MateBook X Pro

--- a/devices/gxfp5187/README.md
+++ b/devices/gxfp5187/README.md
@@ -1,0 +1,50 @@
+# Goodix GXFP5187 (SPI)
+
+**Status: working**
+
+Enrols and verifies through `fprintd` and GNOME Settings; session unlock and
+`sudo` work. Not a USB sensor: it sits on SPI, ACPI id `GXFP5187`.
+
+Upstream libfprint has no driver for this sensor (tracked in
+[libfprint issue #112](https://gitlab.freedesktop.org/libfprint/libfprint/-/issues/112)).
+This entry points at an out-of-tree **TOD** driver (a shared module libfprint
+loads at runtime), not a patch against libfprint's own sources — see
+[patches/](patches/) for the base version and where the code lives.
+
+The driver, its full protocol write-up and the reasoning behind the matcher are
+in the source repository:
+
+**https://github.com/Sigfrodr/libfprint-goodixtls**
+
+## What is different about this sensor
+
+Only the deltas from the shared [../../docs/BUILD.md](../../docs/BUILD.md) steps
+are listed here.
+
+- **It is SPI, not USB.** libfprint reaches it through the `spidev` node. The
+  `spidev` kernel module must be bound to the SPI device (`spi-GXFP5187:00`);
+  the driver ships a udev rule that does this on every appearance. `spidev` has
+  no alias for this hardware, so nothing loads it on its own — the install
+  step forces it.
+- **`spidev` must be given a larger buffer.** The image arrives as a single
+  ~22 kB SPI transfer, above the 4096-byte default; `options spidev
+  bufsiz=65536` is mandatory or the transfer is truncated and capture fails.
+- **A hardware GPIO reset line** (GPIO 58 on `gpiochip0`, per the ACPI `_CRS`)
+  is pulsed by the driver to recover the sensor. `gx-recover.sh` in the source
+  repo unbinds/rebinds `spidev` and pulses it when the sensor deep-locks.
+- **No NBIS.** The sensor is ~6×5 mm and yields far too few minutiae for
+  bozorth3, so the driver carries its own SIFT-like matcher. Nothing to install
+  for it; it is built into the module.
+- **TLS-PSK without Intel ME / SGX.** The pre-shared key is read from the
+  sensor's own RAM; stock OpenSSL is used, no patched crypto library.
+
+Build and install (dependencies, `meson`/`ninja`, the spidev bind, the udev
+rule and the systemd drop-in) are automated by `sudo ./install.sh` in the
+source repository. Session unlock is the generic PAM step from
+[../../docs/BUILD.md](../../docs/BUILD.md).
+
+## Tested on
+
+- **Ubuntu 24.04.4 LTS**, GNOME Shell 46, `libfprint-2-tod1` 1.94.7+tod1.
+- Hardware: **Huawei MateBook X Pro** (`MACH-WX9`), sensor firmware
+  `GF3288_ST411SEC_APP_11033`.

--- a/devices/gxfp5187/patches/README.md
+++ b/devices/gxfp5187/patches/README.md
@@ -1,0 +1,14 @@
+# Patches
+
+This sensor is served by an out-of-tree **TOD** driver — a shared module that
+libfprint loads at runtime — not by a patch series against libfprint's own
+source tree. There are therefore no `.patch` files here; the code lives in its
+own repository and is built and installed as a module.
+
+- Source: https://github.com/Sigfrodr/libfprint-goodixtls
+- Base commit: d7ed1db0c7a229c986a3879e91677f701388a8c1 (branch `main`)
+- Builds against: libfprint-2-tod1 1.94.7+tod1 (Ubuntu 24.04), i.e. the
+  `libfprint-2-tod-1` pkg-config module; the driver targets the TOD ABI, not a
+  specific upstream libfprint commit.
+
+Build and install are automated by `sudo ./install.sh` in that repository.

--- a/docs/laptops.md
+++ b/docs/laptops.md
@@ -17,7 +17,7 @@ lsusb        # find the reader, e.g. 27c6:55b4
 then look it up in the [main README](../README.md), or run
 `./tools/detect.sh` to have it matched for you.
 
-30 model listings map to a catalogued sensor; the rest are on the
+31 model listings map to a catalogued sensor; the rest are on the
 gap-map with no known fix, and a protocol dump for any of them is welcome.
 
 **Adding your machine** is the single most useful small contribution here.
@@ -138,6 +138,7 @@ in practice), **Stale** (abandoned lead), **No known fix**.
 
 | Laptop model | USB ID | Sensor | Status | Where to go |
 |--------------|--------|--------|--------|-------------|
+| Huawei MateBook X Pro | `gxfp5187` | Goodix GXFP5187 (SPI) | Working | [entry](../devices/gxfp5187/) |
 | MagicBook 2019 R7 / Huawei Matebook 13 2020 | `27c6:5117` | - | No known fix | [gap-map](unsupported-devices.md) |
 | Matebook D16 | `27c6:5120` | - | No known fix | [gap-map](unsupported-devices.md) |
 

--- a/tools/check-repo.py
+++ b/tools/check-repo.py
@@ -18,7 +18,7 @@ REPO = Path(__file__).resolve().parent.parent
 DEVICES = REPO / "devices"
 
 # Entries for sensors that are not on USB, so they have no vendor:product ID.
-NON_USB_ENTRIES = {"broadcom-controlvault3", "crfpmoc", "mafp8800"}
+NON_USB_ENTRIES = {"broadcom-controlvault3", "crfpmoc", "gxfp5187", "mafp8800"}
 
 USB_ID = re.compile(r"^[0-9a-f]{4}:[0-9a-f]{4}$")
 ANY_USB_ID = re.compile(r"\b[0-9a-f]{4}:[0-9a-f]{4}\b")


### PR DESCRIPTION
Adds a `devices/gxfp5187/` entry for the **Goodix GXFP5187** SPI fingerprint sensor of the Huawei MateBook X Pro (`MACH-WX9`), unsupported upstream (libfprint #112).

The driver, its full protocol write-up and the reasoning behind the matcher live in a separate repository, which the entry points at:
https://github.com/Sigfrodr/libfprint-goodixtls

### Two things outside the usual shape (flagging for review)

1. **No USB ID.** The sensor is on SPI, so it has no `vendor:product` pair. Following the existing non-USB entries, the directory is `gxfp5187` and I added it to `NON_USB_ENTRIES` in `tools/check-repo.py` — the path the checker's own error message points to. Happy to rename if you prefer another convention.
2. **No `.patch` files.** It is an out-of-tree **TOD** shared module, not a patch series against libfprint's sources, so `patches/README.md` documents the source repo and base commit instead, as CONTRIBUTING allows ("a clear pointer to the branch").

### Checks

- `python3 tools/check-repo.py` → OK, all links and files consistent
- `python3 tools/gen-laptop-index.py --check` → passes; `docs/laptops.md` regenerated with the MateBook X Pro listed

### Tested on

Ubuntu 24.04.4 LTS, GNOME Shell 46, `libfprint-2-tod1` 1.94.7+tod1. Enrols and verifies through fprintd and GNOME Settings; session unlock and sudo work.