### PR TITLE
docs: add 27c6:55b4 Omarchy/Arch report

### DIFF
--- a/devices/27c6:55b4/CREDITS
+++ b/devices/27c6:55b4/CREDITS
@@ -7,3 +7,7 @@ Branch:        goodix-55b4-fixes
 
 Based on the goodixtls libfprint work by TheWeirdDev and contributors.
 Original driver code is LGPL-2.1; this fork keeps that license.
+
+Additional GF32xx driver source tested on Arch/Omarchy:
+https://github.com/GuNanOvO/goodix-55x4-linux
+Release: v0.1.4 (commit c6920bf786c00c5e23882ecc155588dd3c3e8d05)

--- a/devices/27c6:55b4/MODELS
+++ b/devices/27c6:55b4/MODELS
@@ -1,1 +1,2 @@
 Lenovo IdeaPad Flex 5 16ABR8
+Lenovo IdeaPad Flex 5 14ARE05

--- a/devices/27c6:55b4/README.md
+++ b/devices/27c6:55b4/README.md
@@ -3,8 +3,9 @@
 **Status: Working (enroll + verify reliable) via a patched fork.**
 
 Goodix TLS fingerprint sensor, reported by libfprint as **Goodix TLS Fingerprint
-Sensor 55X4**. Firmware family `GF3268_RTSEC_APP_10056`. Found in various
-laptops behind the Goodix `27c6` vendor ID.
+Sensor 55X4**. Confirmed firmware revisions include
+`GF3268_RTSEC_APP_10042` and `GF3268_RTSEC_APP_10056`. Found in various laptops
+behind the Goodix `27c6` vendor ID.
 
 ## What was broken
 
@@ -44,6 +45,44 @@ upstream base commit named in [`patches/README.md`](patches/README.md).
 After installing, `fprintd-list "$USER"` should name **Goodix TLS Fingerprint
 Sensor 55X4**.
 
+### Arch / Omarchy notes
+
+Arch currently exposes OpenCV 5 through `opencv5.pc`. If Meson fails with
+`Dependency "opencv4" not found`, change the sigfm dependency in
+`libfprint/sigfm/meson.build` for that build:
+
+```meson
+opencv = dependency('opencv5', required: true)
+```
+
+When packaging the patched library locally, the package must satisfy both the
+package and shared-library dependencies used by Arch's `fprintd` package:
+
+```bash
+provides=('libfprint=1.94.6' 'libfprint-2.so=2-64')
+conflicts=('libfprint' 'libfprint-git')
+```
+
+Omarchy's stock fingerprint wizard explicitly installs the repository
+`libfprint` package. Pacman will then offer to remove the custom Goodix package,
+which returns this sensor to an unsupported driver. Install `fprintd` directly,
+then enroll and verify with the commands below instead of rerunning the stock
+wizard.
+
+For Omarchy lock-screen integration, create its dedicated PAM service only
+after enrollment and verification succeed:
+
+```bash
+printf '%s\n' \
+  '#%PAM-1.0' \
+  'auth       required                    pam_fprintd.so' \
+  'account    include                     system-local-login' |
+  sudo tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null
+```
+
+This service is used only for the fingerprint path; Omarchy keeps password
+unlock as a separate fallback.
+
 ## Enroll
 
 ```sh
@@ -60,3 +99,6 @@ positions.
 
 - **Lenovo IdeaPad Flex 5 16ABR8** (82XY) on **Void Linux** (libfprint 1.94.6,
   fprintd) - login, sudo, and screen-lock unlock all working.
+- **Lenovo IdeaPad Flex 5 14ARE05** (81X2) on **Omarchy / Arch Linux**
+  (firmware `GF3268_RTSEC_APP_10042`, libfprint 1.94.6, fprintd 1.94.5) -
+  enrollment, verification, and Omarchy screen-lock unlock all working.

--- a/docs/laptops.md
+++ b/docs/laptops.md
@@ -17,7 +17,7 @@ lsusb        # find the reader, e.g. 27c6:55b4
 then look it up in the [main README](../README.md), or run
 `./tools/detect.sh` to have it matched for you.
 
-30 model listings map to a catalogued sensor; the rest are on the
+31 model listings map to a catalogued sensor; the rest are on the
 gap-map with no known fix, and a protocol dump for any of them is welcome.
 
 **Adding your machine** is the single most useful small contribution here.
@@ -35,6 +35,7 @@ in practice), **Stale** (abandoned lead), **No known fix**.
 
 | Laptop model | USB ID | Sensor | Status | Where to go |
 |--------------|--------|--------|--------|-------------|
+| Lenovo IdeaPad Flex 5 14ARE05 | `27c6:55b4` | Goodix GF3268 | Working | [entry](../devices/27c6:55b4/) |
 | Lenovo IdeaPad Flex 5 16ABR8 | `27c6:55b4` | Goodix GF3268 | Working | [entry](../devices/27c6:55b4/) |
 | Lenovo ThinkPad E14 Gen 5 | `10a5:9800` | FPC Match-on-Host / fpcmoh | Working | [entry](../devices/10a5:9800/) |
 | Lenovo ThinkBook | `27c6:550a` | Goodix 550a - vendor TOD blob route | Working (vendor blob) | [entry](../devices/27c6:550a/) |


### PR DESCRIPTION
## Summary

- record Lenovo IdeaPad Flex 5 14ARE05 (81X2) with Goodix 27c6:55b4
- confirm GF3268_RTSEC_APP_10042 enrollment, verification, and screen-lock unlock on Omarchy/Arch
- document the OpenCV 5 Meson dependency name and Arch package soname provides
- document the Omarchy stock-wizard package conflict and dedicated lock-screen PAM service
- credit the additional GF32xx fork used for the test

## Validation

- `python3 tools/gen-laptop-index.py`
- `python3 tools/check-repo.py`
- `git diff --check`

Repository validation reports: `OK: 41 device entries, all links and files consistent.`

No fingerprint captures, templates, USB traces, usernames, hostnames, or other biometric/private data are included.
