### PR TITLE
Confirm broken links before filing an issue

### DIFF
--- a/.github/workflows/link-rot.yml
+++ b/.github/workflows/link-rot.yml
@@ -13,6 +13,14 @@ permissions:
   contents: read
   issues: write
 
+env:
+  # Kept in one place so the first pass and the confirmation pass below can
+  # never drift apart.
+  LYCHEE_ARGS: >-
+    --no-progress --max-concurrency 4 --accept 200,206,429
+    --max-retries 5 --retry-wait-time 15
+    README.md CONTRIBUTING.md docs/*.md 'devices/**/*.md'
+
 jobs:
   external-links:
     runs-on: ubuntu-latest
@@ -23,15 +31,30 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: >-
-            --no-progress --max-concurrency 4 --accept 200,206,429
-            README.md CONTRIBUTING.md docs/*.md 'devices/**/*.md'
+          args: ${{ env.LYCHEE_ARGS }}
+          fail: false
+
+      # git.launchpad.net and gitlab.freedesktop.org both hand out sporadic
+      # 500s to CI runners for pages that are perfectly alive, so a single bad
+      # answer is not evidence of link rot. Wait for the upstream hiccup to
+      # pass, ask again, and only file an issue if the second run agrees.
+      - name: Wait out transient upstream errors
+        if: steps.lychee.outputs.exit_code != 0
+        run: sleep 180
+
+      - name: Re-check external links
+        id: recheck
+        if: steps.lychee.outputs.exit_code != 0
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: ${{ env.LYCHEE_ARGS }}
+          output: ./lychee/recheck.md
           fail: false
 
       - name: Open an issue if links are broken
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.lychee.outputs.exit_code != 0 && steps.recheck.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Broken links found by the weekly link check
-          content-filepath: ./lychee/out.md
+          content-filepath: ./lychee/recheck.md
           labels: maintenance


### PR DESCRIPTION
Closes #14.

## What the issue actually was

Both links issue #14 flagged are alive. Checked from here just now, with lycheeʼs own user agent as well as a browser one:

```
https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-goodix/+git/libfprint-2-tod1-goodix/   -> 200
https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-broadcom/+git/libfprint-2-tod1-broadcom/ -> 200
```

I swept all 67 external URLs in `README.md`, `CONTRIBUTING.md`, `docs/*.md` and `devices/*/*.md`. Every one answers. Two came back 5xx on the first attempt and 200 on the second: `git.launchpad.net` and, separately, libfprint MR !396 on `gitlab.freedesktop.org`. So both of the hosts this repo depends on most hand out sporadic 500s, and the weekly job has been reporting them as link rot.

## The fix

A single bad answer from an upstream host is not evidence of link rot, so the workflow no longer treats it as such:

- Retry harder inside a run (`--max-retries 5 --retry-wait-time 15`).
- If a run still comes back dirty, sleep three minutes and check again. The issue is only filed when the second pass agrees, and it is filed from the second passʼs report.
- Both passes read their arguments from one `LYCHEE_ARGS` env var so they cannot drift apart.

Real link rot (a 404, a repo that is gone) survives both passes untouched. An upstream hiccup does not, which is what was generating the noise.

## Not changed

No documentation or device entry needed editing — nothing in the catalogue is stale. `python3 tools/check-repo.py` passes: 42 device entries, all links and files consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183vhHFugJzZwMuBmWPEXs3