### PR TITLE
Add 04f3:0c80 entry: ELAN ARM-M4 on Surface Laptop Go 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ in libfprint and may be unstable; see each device entry for details.
 |-----------|---------------|--------|-------|
 | 27c6:521d (538d) | Goodix 521d/538d | [goodix-fp-linux-dev](https://github.com/goodix-fp-linux-dev) | Works via AUR `libfprint-goodix-521d` |
 | 27c6:5110 + family | Goodix (newer) | [goodix-fp-linux-dev/libfprint](https://github.com/goodix-fp-linux-dev/libfprint) | **Experimental, not for daily use** |
+| [04f3:0c80](devices/04f3:0c80/) | ELAN ARM-M4 (Surface Laptop Go 2) | [patch on Depau's libfprint](devices/04f3:0c80/patches/) | Enroll + verify work; **clearing sensor storage still times out**, and re-enroll wipes all prints |
 
 
 ## Claimed upstream, but unreliable

--- a/devices/04f3:0c80/CREDITS
+++ b/devices/04f3:0c80/CREDITS
@@ -1,0 +1,18 @@
+Device: ELAN ARM-M4 (USB 04f3:0c80)
+Device ID(s): 04f3:0c80
+
+Status: experimental community patch, not upstream
+
+Reported and tested by: ChuChua-Tech (@ChuChua-Tech)
+  Report and patch: https://gist.github.com/ChuChua-Tech/37e7636c0276974547ff36e3ee51030e
+  Origin issue: https://github.com/jedbillyb/linux-fingerprint-drivers/issues/16
+
+Patch base: Davide Depau's libfprint fork, commit
+  11f0316d069cc90c154c8cb0e46478388c5e2a74
+  https://gitlab.freedesktop.org/Depau/libfprint.git
+
+The EP83 and NO_DELETE_BY_ID quirks come from the Surface Laptop Go 1
+(04f3:0c5a) reports in linux-surface:
+  https://github.com/linux-surface/linux-surface/issues/1380
+
+Part of libfprint (LGPL-2.1). Experimental - not production ready.

--- a/devices/04f3:0c80/MODELS
+++ b/devices/04f3:0c80/MODELS
@@ -1,0 +1,1 @@
+Microsoft Surface Laptop Go 2

--- a/devices/04f3:0c80/README.md
+++ b/devices/04f3:0c80/README.md
@@ -1,0 +1,90 @@
+# ELAN ARM-M4 (USB 04f3:0c80)
+
+**Status: Partial - enroll and verify work with an experimental local patch, but clearing sensor storage still times out and re-enrolling wipes every stored print.**
+
+ELAN "ARM-M4" match-on-chip fingerprint reader, reported in the Surface Laptop
+Go 2.
+
+## What was broken
+
+The USB ID is not in any `elanmoc2` ID table, upstream or in the community
+forks, so a stock install never binds a driver to it. `fprintd-enroll` fails
+with `NoSuchDevice` and the daemon logs:
+
+```text
+No driver found for USB device 04F3:0C80
+```
+
+## What the fix does
+
+Patches Davide Depau's `elanmoc2` branch to add the sensor and three quirks it
+needs. Only one machine has been tested, and the erase path is not fully
+solved, so treat this as a lead rather than a finished driver.
+
+- Adds `04f3:0c80` to the `elanmoc2` ID table.
+- `ELANMOC2_QUIRK_USE_EP83` routes identify and enroll replies to endpoint
+  `0x83` instead of `0x84`.
+- `ELANMOC2_QUIRK_NO_DELETE_BY_ID` skips per-finger deletion during
+  re-enrollment and falls through to the whole-sensor wipe. **This is not
+  selective deletion: re-enrolling can remove every stored print.**
+- `ELANMOC2_QUIRK_WIPE_ACK` reads a device-specific two-byte reply after the
+  `40 ff 99` erase command, then waits five seconds before the next state.
+- Clears `in_flight_cmd` on transfer error and guards overlapping commands and
+  close-time cancellation. These stop an earlier assertion, but dropping
+  commands is a workaround and the cancellation lifecycle still needs review.
+
+The EP83 and no-delete-by-ID leads came from the same quirk pair working on a
+Surface Laptop Go 1 (`04f3:0c5a`) on Fedora.
+
+## Known limitation
+
+Clearing storage before the first enrollment still fails:
+
+```text
+Erase acknowledgement received; waiting for sensor
+SSM CLEAR_STORAGE_NUM_STATES failed in state 1 with error: transfer timed out
+Failed to clear storage before first enrollment: transfer timed out
+```
+
+fprintd carries on regardless: the following count/identify succeeds, reports
+zero stored fingers, and enrollment completes. It is not established whether
+recovery comes from the acknowledgement handling, the added delay, or both.
+Cold boot, suspend/resume, repeated delete and re-enroll, and multi-finger
+reliability are all untested.
+
+## Build and install
+
+The patch applies to Davide Depau's `libfprint` fork at commit
+`11f0316d069cc90c154c8cb0e46478388c5e2a74` ("WIP add 0c7c"), **not** to the
+current `xerootg` branch, where quirk names and surrounding code differ. See
+`patches/README.md` for the base commit and
+[docs/BUILD.md](../../docs/BUILD.md) for the shared build, install and PAM
+steps. The deltas for this sensor:
+
+```sh
+git clone https://gitlab.freedesktop.org/Depau/libfprint.git
+cd libfprint
+git checkout 11f0316d069cc90c154c8cb0e46478388c5e2a74
+git apply /path/to/patches/0001-elanmoc2-add-04f3-0c80.patch
+
+meson setup build-slg2 --prefix=/usr --libdir=lib \
+  -Ddoc=false -Dinstalled-tests=false -Ddrivers=elanmoc2
+meson compile -C build-slg2
+sudo meson install -C build-slg2 --no-rebuild
+sudo systemctl restart fprintd
+```
+
+On Arch the GLib development tools must be present, `glib-mkenums` in
+particular. Reproduction from a fresh checkout has not been independently
+tested.
+
+> This replaces your distro's libfprint. Keep a way to reinstall the stock
+> package, which will also silently undo this driver on the next update.
+
+## Tested on
+
+- Omarchy (Arch), kernel 7.1.9-arch1-2, Surface Laptop Go 2. Enroll and verify
+  both succeed, verify still matches after restarting fprintd, and fingerprint
+  authentication for `sudo` was confirmed working. Single reporter, single
+  machine.
+- Originally reported as `NoSuchDevice` on the same machine before the patch.

--- a/devices/04f3:0c80/patches/0001-elanmoc2-add-04f3-0c80.patch
+++ b/devices/04f3:0c80/patches/0001-elanmoc2-add-04f3-0c80.patch
@@ -1,0 +1,178 @@
+diff --git a/libfprint/drivers/elanmoc2/elanmoc2.c b/libfprint/drivers/elanmoc2/elanmoc2.c
+index bec6aeb..7ebdb59 100644
+--- a/libfprint/drivers/elanmoc2/elanmoc2.c
++++ b/libfprint/drivers/elanmoc2/elanmoc2.c
+@@ -56,6 +56,9 @@ struct _FpiDeviceElanMoC2
+   FpPrint *enroll_print;
+ };
+ 
++static guint8
++elanmoc2_cmd_ep_in_for_device (FpiDeviceElanMoC2 *self, const Elanmoc2Cmd *cmd);
++
+ G_DEFINE_TYPE (FpiDeviceElanMoC2, fpi_device_elanmoc2, FP_TYPE_DEVICE);
+ 
+ 
+@@ -66,7 +69,6 @@ elanmoc2_cmd_usb_callback (FpiUsbTransfer *transfer,
+                            GError         *error)
+ {
+   FpiDeviceElanMoC2 *self = FPI_DEVICE_ELANMOC2 (device);
+-  const gboolean short_is_error = GPOINTER_TO_INT (user_data);
+ 
+   if (self->ssm == NULL)
+     {
+@@ -85,6 +87,7 @@ elanmoc2_cmd_usb_callback (FpiUsbTransfer *transfer,
+ 
+   if (error)
+     {
++      self->in_flight_cmd = NULL;
+       fpi_ssm_mark_failed (g_steal_pointer (&self->ssm),
+                            g_steal_pointer (&error));
+       return;
+@@ -94,8 +97,12 @@ elanmoc2_cmd_usb_callback (FpiUsbTransfer *transfer,
+     {
+       /* Send callback */
+       const Elanmoc2Cmd *cmd = g_steal_pointer (&self->in_flight_cmd);
++      const gboolean short_is_error = GPOINTER_TO_INT (user_data);
++      const gint in_len =
++        cmd == &cmd_wipe_sensor && (self->dev_type & ELANMOC2_QUIRK_WIPE_ACK) ?
++        2 : cmd->in_len;
+ 
+-      if (cmd->in_len == 0)
++      if (in_len == 0)
+         {
+           /* Nothing to receive */
+           fpi_ssm_next_state (self->ssm);
+@@ -106,15 +113,16 @@ elanmoc2_cmd_usb_callback (FpiUsbTransfer *transfer,
+ 
+       transfer_in->short_is_error = short_is_error;
+ 
+-      fpi_usb_transfer_fill_bulk (transfer_in, cmd->ep_in,
+-                                  cmd->in_len);
++      fpi_usb_transfer_fill_bulk (transfer_in,
++                                  elanmoc2_cmd_ep_in_for_device (self, cmd),
++                                  in_len);
+ 
+       fpi_usb_transfer_submit (transfer_in,
+                                ELANMOC2_USB_RECV_TIMEOUT,
+                                cmd->is_cancellable ?
+                                fpi_device_get_cancellable (device) : NULL,
+                                elanmoc2_cmd_usb_callback,
+-                               NULL);
++                               (gpointer) cmd);
+     }
+   else
+     {
+@@ -132,11 +140,30 @@ elanmoc2_cmd_usb_callback (FpiUsbTransfer *transfer,
+           self->buffer_in =
+             g_bytes_new_take (g_steal_pointer (&(transfer->buffer)),
+                               transfer->actual_length);
+-          fpi_ssm_next_state (self->ssm);
++          if (user_data == &cmd_wipe_sensor &&
++              (self->dev_type & ELANMOC2_QUIRK_WIPE_ACK))
++            {
++              /* Consume the erase acknowledgement before issuing another
++               * command, and allow the sensor time to finish erasing. */
++              fp_info ("Erase acknowledgement received; waiting for sensor");
++              fpi_ssm_next_state_delayed (self->ssm, 5000);
++            }
++          else
++            fpi_ssm_next_state (self->ssm);
+         }
+     }
+ }
+ 
++static guint8
++elanmoc2_cmd_ep_in_for_device (FpiDeviceElanMoC2 *self, const Elanmoc2Cmd *cmd)
++{
++  if ((self->dev_type & ELANMOC2_QUIRK_USE_EP83) &&
++      (cmd == &cmd_identify || cmd == &cmd_enroll))
++    return ELANMOC2_EP_MOC_CMD_IN_83;
++
++  return cmd->ep_in;
++}
++
+ static void
+ elanmoc2_cmd_transceive_full (FpDevice          *device,
+                               const Elanmoc2Cmd *cmd,
+@@ -147,7 +174,11 @@ elanmoc2_cmd_transceive_full (FpDevice          *device,
+   FpiDeviceElanMoC2 *self = FPI_DEVICE_ELANMOC2 (device);
+ 
+   g_assert (buffer_out->len == cmd->out_len);
+-  g_assert_null (self->in_flight_cmd);
++  if (self->in_flight_cmd != NULL)
++    {
++      fp_warn ("Command started while previous command still in flight, dropping");
++      return;
++    }
+   self->in_flight_cmd = cmd;
+ 
+   g_autoptr(FpiUsbTransfer) transfer_out = fpi_usb_transfer_new (device);
+@@ -323,9 +354,13 @@ static void
+ elanmoc2_close (FpDevice *device)
+ {
+   g_autoptr(GError) error = NULL;
++  FpiDeviceElanMoC2 *self = FPI_DEVICE_ELANMOC2 (device);
+ 
+   fp_info ("Closing device");
+-  elanmoc2_cancel (device);
++  if (self->in_flight_cmd == NULL)
++    elanmoc2_cancel (device);
++  else
++    fp_info ("Skipping cancel while command is still in flight");
+   g_usb_device_release_interface (fpi_device_get_usb_device (FP_DEVICE (device)),
+                                   0, 0, &error);
+   fpi_device_close_complete (device, g_steal_pointer (&error));
+@@ -826,6 +861,12 @@ elanmoc2_enroll_run_state (FpiSsm *ssm, FpDevice *device)
+ 
+     case ENROLL_ATTEMPT_DELETE: {
+         fpi_device_report_finger_status (device, FP_FINGER_STATUS_NONE);
++        if (self->dev_type & ELANMOC2_QUIRK_NO_DELETE_BY_ID)
++          {
++            fp_info ("NO_DELETE_BY_ID quirk set, skipping delete by ID");
++            fpi_ssm_jump_to_state (ssm, ENROLL_WIPE_SENSOR);
++            break;
++          }
+         fp_info ("Deleting enrolled finger %d", self->print_index);
+         g_assert_nonnull (buffer_in);
+ 
+@@ -886,7 +927,6 @@ elanmoc2_enroll_run_state (FpiSsm *ssm, FpDevice *device)
+         self->print_index = 0;
+         fp_info (
+           "Wipe sensor command sent - next operation will take a while");
+-        fpi_ssm_next_state (ssm);
+         break;
+       }
+ 
+@@ -1159,6 +1199,10 @@ fpi_device_elanmoc2_init (FpiDeviceElanMoC2 *self)
+ static const FpIdEntry elanmoc2_id_table[] = {
+   {.vid = ELANMOC2_VEND_ID, .pid = 0x0c00, .driver_data = ELANMOC2_ALL_DEV},
+   {.vid = ELANMOC2_VEND_ID, .pid = 0x0c4c, .driver_data = ELANMOC2_ALL_DEV},
++  {.vid = ELANMOC2_VEND_ID, .pid = 0x0c80, .driver_data = ELANMOC2_ALL_DEV |
++   ELANMOC2_QUIRK_USE_EP83 |
++   ELANMOC2_QUIRK_NO_DELETE_BY_ID |
++   ELANMOC2_QUIRK_WIPE_ACK},
+   {.vid = ELANMOC2_VEND_ID, .pid = 0x0c5e, .driver_data = ELANMOC2_DEV_0C5E},
+   {.vid = ELANMOC2_VEND_ID, .pid = 0x0c7c, .driver_data = ELANMOC2_ALL_DEV},
+   {.vid = ELANMOC2_VEND_ID, .pid = 0x0c90, .driver_data = ELANMOC2_ALL_DEV},
+diff --git a/libfprint/drivers/elanmoc2/elanmoc2.h b/libfprint/drivers/elanmoc2/elanmoc2.h
+index 2a99089..7cb21a2 100644
+--- a/libfprint/drivers/elanmoc2/elanmoc2.h
++++ b/libfprint/drivers/elanmoc2/elanmoc2.h
+@@ -46,6 +46,7 @@
+ #define ELANMOC2_EP_CMD_OUT (0x1 | FPI_USB_ENDPOINT_OUT)
+ #define ELANMOC2_EP_CMD_IN (0x3 | FPI_USB_ENDPOINT_IN)
+ #define ELANMOC2_EP_MOC_CMD_IN (0x4 | FPI_USB_ENDPOINT_IN)
++#define ELANMOC2_EP_MOC_CMD_IN_83 (0x3 | FPI_USB_ENDPOINT_IN)
+ #define ELANMOC2_USB_SEND_TIMEOUT 10000
+ #define ELANMOC2_USB_RECV_TIMEOUT 10000
+ 
+@@ -62,6 +63,9 @@
+ // Currently only one device is supported, but I'd like to future-proof this driver for any new contributions.
+ #define ELANMOC2_ALL_DEV 0
+ #define ELANMOC2_DEV_0C5E (1 << 0)
++#define ELANMOC2_QUIRK_USE_EP83 (1 << 1)
++#define ELANMOC2_QUIRK_NO_DELETE_BY_ID (1 << 2)
++#define ELANMOC2_QUIRK_WIPE_ACK (1 << 3)
+ 
+ // Subtract the 2-byte header
+ #define ELANMOC2_USER_ID_MAX_LEN (cmd_finger_info.in_len - 2)

--- a/devices/04f3:0c80/patches/README.md
+++ b/devices/04f3:0c80/patches/README.md
@@ -1,0 +1,18 @@
+# Patches for ELAN ARM-M4 (0c80)
+
+`0001-elanmoc2-add-04f3-0c80.patch` applies to Davide Depau's libfprint fork at
+commit `11f0316d069cc90c154c8cb0e46478388c5e2a74` ("WIP add 0c7c"):
+
+```sh
+git clone https://gitlab.freedesktop.org/Depau/libfprint.git
+cd libfprint
+git checkout 11f0316d069cc90c154c8cb0e46478388c5e2a74
+git apply 0001-elanmoc2-add-04f3-0c80.patch
+```
+
+It does **not** apply to the current `xerootg` branch; the quirk names and the
+surrounding code differ there. Rebasing it onto a maintained branch, and
+solving the erase timeout documented in the entry README, are the two open
+pieces of work.
+
+Source: https://gist.github.com/ChuChua-Tech/37e7636c0276974547ff36e3ee51030e

--- a/docs/laptops.md
+++ b/docs/laptops.md
@@ -17,7 +17,7 @@ lsusb        # find the reader, e.g. 27c6:55b4
 then look it up in the [main README](../README.md), or run
 `./tools/detect.sh` to have it matched for you.
 
-32 model listings map to a catalogued sensor; the rest are on the
+33 model listings map to a catalogued sensor; the rest are on the
 gap-map with no known fix, and a protocol dump for any of them is welcome.
 
 **Adding your machine** is the single most useful small contribution here.
@@ -165,7 +165,7 @@ in practice), **Stale** (abandoned lead), **No known fix**.
 
 | Laptop model | USB ID | Sensor | Status | Where to go |
 |--------------|--------|--------|--------|-------------|
-| ELAN:ARM-M4 - Surface Laptop Go 2 | `04f3:0c80` | - | No known fix | [gap-map](unsupported-devices.md) |
+| Microsoft Surface Laptop Go 2 | `04f3:0c80` | ELAN ARM-M4 | Partial | [entry](../devices/04f3:0c80/) |
 | Surface Laptop Go | `04f3:0c5a` | - | No known fix | [gap-map](unsupported-devices.md) |
 
 ## MSI

--- a/docs/unsupported-devices.md
+++ b/docs/unsupported-devices.md
@@ -1,6 +1,6 @@
 # Devices with no known fix (contributor gap-map)
 
-The 104 USB fingerprint sensors below are on the official libfprint
+The 103 USB fingerprint sensors below are on the official libfprint
 [Unsupported Devices](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Unsupported-Devices)
 list and have **no working driver here or upstream**. Devices already covered by
 an entry in [`devices/`](../devices/) (working or WIP) are omitted - check the
@@ -11,7 +11,7 @@ have one of these, a protocol dump or a driver is welcome.
 noted on the wiki.
 
 Source: libfprint wiki, fetched 2026-06-18. Rows are removed as devices gain
-an entry; last reconciled 2026-08-02.
+an entry; last reconciled 2026-09-07.
 
 Most USB IDs below are plain text rather than links: the wiki's own
 `Unsupported-Devices` table links each device to a `Devices/<id>` subpage, but
@@ -42,7 +42,6 @@ VCSFW driver (MR [!579](https://gitlab.freedesktop.org/libfprint/libfprint/-/mer
 | `04f3:0c77` | - | partial |
 | `04f3:0c7c` | - | WIP/PoC upstream |
 | `04f3:0c7f` | Acer Swift 3 |  |
-| `04f3:0c80` | ELAN:ARM-M4 - Surface Laptop Go 2 |  |
 | `04f3:0c85` | ELAN:ARM-M4 ACER Aspire Vero |  |
 | `04f3:0c8a` | - |  |
 | `04f3:0c90` | ELAN:ARM-M4 ASUS Vivobook |  |


### PR DESCRIPTION
Closes #16.

`04f3:0c80` is in no `elanmoc2` ID table, upstream or in the community forks, so a stock install never binds a driver and `fprintd` logs `No driver found for USB device 04F3:0C80`. @ChuChua-Tech reported that, then got enroll and verify working with a local patch and published it. This catalogues that result.

### The patch

Applies to Davide Depau's fork at `11f0316d069cc90c154c8cb0e46478388c5e2a74` ("WIP add 0c7c"), **not** the current `xerootg` branch where the quirk names differ. I fetched that commit and ran `git apply --check`: both files apply clean.

- adds `04f3:0c80` to the ID table
- `QUIRK_USE_EP83`, routing identify/enroll replies to `0x83`
- `QUIRK_NO_DELETE_BY_ID`, which skips per-finger deletion and falls through to the whole-sensor wipe, so it is not selective deletion
- `QUIRK_WIPE_ACK`, a two-byte reply after `40 ff 99` plus a five second wait
- in-flight command and close-time cancellation guards

The EP83 and no-delete-by-ID leads came from the Surface Laptop Go 1 (`04f3:0c5a`) reports in linux-surface/linux-surface#1380.

### Why Partial, not Working

Clearing storage before the first enrollment still times out. `fprintd` carries on, the next count/identify succeeds and enrollment completes, but whether recovery comes from the acknowledgement handling, the added delay or both is not established, and the cancellation guards are workarounds rather than a reviewed lifecycle fix. Cold boot, suspend/resume, repeated delete and re-enroll, and multi-finger are all untested. One machine, one reporter. The entry README says so up front.

### Also in here

- gap-map row removed, count 104 to 103. The "2 of the 104 pages" sentence is about the upstream wiki's own subpages, so it is left alone.
- `docs/laptops.md` regenerated, picking up Microsoft Surface Laptop Go 2.
- `python3 tools/check-repo.py` passes: 43 entries, links and files consistent.