### PR TITLE
Add 2df0:0003 entry: CanvasBio CB2000, and warn off 2df0:0007

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ in libfprint and may be unstable; see each device entry for details.
 |-----------|---------------|--------|-------|
 | 27c6:521d (538d) | Goodix 521d/538d | [goodix-fp-linux-dev](https://github.com/goodix-fp-linux-dev) | Works via AUR `libfprint-goodix-521d` |
 | 27c6:5110 + family | Goodix (newer) | [goodix-fp-linux-dev/libfprint](https://github.com/goodix-fp-linux-dev/libfprint) | **Experimental, not for daily use** |
+| [2df0:0003](devices/2df0:0003/) | CanvasBio CB2000 (Samsung Galaxy Book2/Book3 360) | [four independent drivers](devices/2df0:0003/#the-drivers) | Two report daily use. **`2df0:0007` is a different part and is not supported by any of them** |
 | [04f3:0c80](devices/04f3:0c80/) | ELAN ARM-M4 (Surface Laptop Go 2) | [patch on Depau's libfprint](devices/04f3:0c80/patches/) | Enroll + verify work; **clearing sensor storage still times out**, and re-enroll wipes all prints |
 
 

--- a/devices/2df0:0003/CREDITS
+++ b/devices/2df0:0003/CREDITS
@@ -1,0 +1,32 @@
+Device: CanvasBio CB2000 (USB 2df0:0003)
+Device ID(s): 2df0:0003
+
+Status: working via community drivers, none upstream. No libfprint merge
+request exists for 2df0 in any state.
+
+Driver authors (independent efforts, all reverse-engineered from the Samsung
+Windows driver):
+
+  Kaue Pagnussat (@kpagnussat) - CanvasMancer, SIGFM matcher, LGPL-2.1
+    https://github.com/kpagnussat/canvasbio-cb2000
+    https://gitlab.com/-/snippets/4931207
+
+  Lennart Arnholdt (@LennartArnholdt) - SIFT matcher, LGPL-2.1-or-later AND MIT
+    https://github.com/LennartArnholdt/libfprint-tod-cb2000
+    SIGFM-derived method carries an MIT notice in sift_match.hpp
+
+  @latex - standalone driver and CLI tooling, MIT
+    https://github.com/latex/canvasbio-cb2000-linux-driver
+
+  @rfocosi - libfprint fork carrying a CB2000 driver, no licence stated
+    https://github.com/rfocosi/libfprint
+
+  @vgperess - earliest published attempt, no licence stated
+    https://github.com/vgperess/libfprint-canvasbio-cb2000
+
+Protocol notes on the sibling 2df0:0007 (match-on-chip, SDCP/TLS), third-party
+and unverified:
+  https://github.com/myso-kr/samsung-galaxy-book-fingerprint-sensor-device-730b
+
+No code from any of the above is hosted here. Licences are recorded so you can
+check compatibility before mixing them into libfprint (LGPL-2.1).

--- a/devices/2df0:0003/MODELS
+++ b/devices/2df0:0003/MODELS
@@ -1,0 +1,2 @@
+Samsung Galaxy Book3 360
+Samsung Galaxy Book2 360

--- a/devices/2df0:0003/README.md
+++ b/devices/2df0:0003/README.md
@@ -1,0 +1,95 @@
+# CanvasBio CB2000 (USB 2df0:0003)
+
+**Status: Working via community drivers, none of them upstream; the sibling ID `2df0:0007` is not covered by any of them and stalls on contact.**
+
+CanvasBio CB2000, the fingerprint reader in the Samsung Galaxy Book2 360 and
+Book3 360 generation. Upstream libfprint has never supported it and there is no
+merge request for `2df0` in any state, but four independent people have
+reverse-engineered it from the Samsung Windows driver, and at least two report
+daily use for login and `sudo`.
+
+## What was broken
+
+The sensor is unknown to stock libfprint, so nothing binds to it and
+`fprintd-enroll` reports no devices.
+
+Worse, it does not fit libfprint's normal image path even once you can talk to
+it. The CB2000 delivers an 80x64 greyscale image covering roughly 5x4 mm of
+fingertip. NBIS/bozorth3 wants somewhere around 20 minutiae to match; on frames
+this small it typically finds 0 to 3. Neither adjusting `ppmm` nor upscaling
+helps, because the minutiae are not in the frame to begin with. Every working
+driver below therefore derives from `FpDevice` rather than `FpImageDevice` and
+brings its own matcher, building a template from many frames instead of one.
+
+## The drivers
+
+None of these is upstream, none is packaged by a distro, and all of them
+replace or extend your libfprint. Read the source before installing.
+
+| Project | Approach | Licence | Notes |
+|---------|----------|---------|-------|
+| [kpagnussat/canvasbio-cb2000](https://github.com/kpagnussat/canvasbio-cb2000) | SIGFM feature matching, multi-capture mosaic template | LGPL-2.1 | Most actively developed. `R2.5` snapshot, 15 enroll stages, requires OpenCV, disables libfprint's virtual thermal shutdown for this device. Also published as a [single-file snippet](https://gitlab.com/-/snippets/4931207) |
+| [LennartArnholdt/libfprint-tod-cb2000](https://github.com/LennartArnholdt/libfprint-tod-cb2000) | SIFT feature matching, 30-frame template | LGPL-2.1-or-later AND MIT | Reports ~83% single-touch genuine acceptance and 0 false accepts in 1080 comparisons, measured across separate sessions on one device. PAM setup documented |
+| [latex/canvasbio-cb2000-linux-driver](https://github.com/latex/canvasbio-cb2000-linux-driver) | Standalone driver plus CLI tooling (`cb2000_demo`, `fpsudo`) | MIT | Ships an `install.sh`. Developed on a Book3 360 (730QFG) |
+| [rfocosi/libfprint](https://github.com/rfocosi/libfprint) | libfprint fork carrying a CB2000 driver | none stated | Whole-library fork rather than a patch |
+| [vgperess/libfprint-canvasbio-cb2000](https://github.com/vgperess/libfprint-canvasbio-cb2000) | - | none stated | Earliest of the set, quiet since 2025 |
+
+**On licensing:** this repo hosts none of the above, it points at them. The MIT
+and unlicensed ones are noted so you can make your own call before mixing code
+into an LGPL-2.1 library.
+
+## Do not use these on 2df0:0007
+
+`2df0:0007` is a different part in the same family, reported in the Samsung
+Galaxy Book5 360. It is **not** supported by any driver here, and at least one
+of them lists the ID anyway.
+
+kpagnussat's `id_table` carries both `0x0003` and `0x0007`, but nothing else in
+that driver looks at which product it is talking to, so a `:0007` binds and is
+then driven with a command set traced entirely off `:0003` hardware. The
+observed result is an immediate stall on the first vendor control request of
+the wake sequence, followed by an endless USB reset and re-init loop:
+
+```text
+[activation_wake] cmd 1/10 CTRL_OUT req=0xdb value=0x0001 index=1
+Command transfer failed: endpoint stalled or request not supported
+```
+
+Reverse-engineering notes in
+[myso-kr/samsung-galaxy-book-fingerprint-sensor-device-730b](https://github.com/myso-kr/samsung-galaxy-book-fingerprint-sensor-device-730b/blob/main/docs/reverse-engineering/driver-analysis.md)
+describe `2df0:0007` as match-on-chip with SDCP and TLS, off a Realtek UMDF
+driver, against the plain unencrypted image sensor that `:0003` is known to be.
+That is third-party and unverified, but it is consistent with a device
+rejecting a bare vendor request outright.
+
+If you have a `:0007`, the useful contribution is a full `lsusb -v` dump,
+especially the BOS descriptor, and a Windows-side USB capture if you can get
+one. Tracked in
+[issue #17](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/17).
+
+## Build and install
+
+Each project ships its own instructions and they differ, so follow the one you
+pick. [docs/BUILD.md](../../docs/BUILD.md) covers the shared shape: building
+libfprint from source, installing over your distro's copy, PAM setup and
+troubleshooting. Sensor-specific deltas:
+
+- kpagnussat's `R2.5` needs OpenCV present at build and run time, and enrolls
+  in 15 stages rather than the usual 5, so expect a longer enrollment.
+- Templates are multi-frame for every driver here. Re-enroll after switching
+  drivers rather than expecting old prints to carry over.
+- Expect to re-touch on some verifications. A 5x4 mm capture area means two
+  presses can share almost no skin, so allow three PAM attempts.
+
+> These replace a core system library. Keep a way to reinstall your distro's
+> stock libfprint, which will also silently undo the driver on the next update.
+
+## Tested on
+
+- Samsung Galaxy Book3 360, daily use for login and `sudo`, per
+  LennartArnholdt's and kpagnussat's own reports. Both note their accuracy
+  figures come from one person on one device.
+- Samsung Galaxy Book2 360, reported as working but stricter, sometimes needing
+  threshold tuning.
+- `2df0:0003` also recorded on a Samsung 730QED by a linuxhw hardware probe
+  under Fedora 38.

--- a/devices/2df0:0003/patches/README.md
+++ b/devices/2df0:0003/patches/README.md
@@ -1,0 +1,12 @@
+# Patches for CanvasBio CB2000 (2df0:0003)
+
+There is no local patch series here. Each driver lives in its own repository,
+listed in `../CREDITS`, and they are separate implementations rather than
+variants of one patch set.
+
+If you export a patch against a specific libfprint revision, drop the numbered
+`.patch` files here and state the base commit.
+
+Start with [kpagnussat/canvasbio-cb2000](https://github.com/kpagnussat/canvasbio-cb2000)
+(branch `R2.5`) or [LennartArnholdt/libfprint-tod-cb2000](https://github.com/LennartArnholdt/libfprint-tod-cb2000);
+those two are the maintained ones.

--- a/docs/laptops.md
+++ b/docs/laptops.md
@@ -17,7 +17,7 @@ lsusb        # find the reader, e.g. 27c6:55b4
 then look it up in the [main README](../README.md), or run
 `./tools/detect.sh` to have it matched for you.
 
-33 model listings map to a catalogued sensor; the rest are on the
+35 model listings map to a catalogued sensor; the rest are on the
 gap-map with no known fix, and a protocol dump for any of them is welcome.
 
 **Adding your machine** is the single most useful small contribution here.
@@ -132,6 +132,8 @@ in practice), **Stale** (abandoned lead), **No known fix**.
 
 | Laptop model | USB ID | Sensor | Status | Where to go |
 |--------------|--------|--------|--------|-------------|
+| Samsung Galaxy Book2 360 | `2df0:0003` | CanvasBio CB2000 | Working | [entry](../devices/2df0:0003/) |
+| Samsung Galaxy Book3 360 | `2df0:0003` | CanvasBio CB2000 | Working | [entry](../devices/2df0:0003/) |
 | Samsung Galaxy Book 4 | `2808:6553` | FocalTech FT9365 ESS (focaltech_moc) | Merged upstream | [entry](../devices/2808:6553/) |
 | Samsung GalaxyBook Pro 360 | `1c7a:057e` | - | No known fix | [gap-map](unsupported-devices.md) |
 
@@ -194,7 +196,6 @@ in practice), **Stale** (abandoned lead), **No known fix**.
 
 | Laptop model | USB ID | Sensor | Status | Where to go |
 |--------------|--------|--------|--------|-------------|
-| CanvasBio CB2000 | `2df0:0003` | - | No known fix | [gap-map](unsupported-devices.md) |
 | Clevo Laptops | `06cb:00a8` | - | No known fix | [gap-map](unsupported-devices.md) |
 | realme book MP | `27c6:5e0a` | - | No known fix | [gap-map](unsupported-devices.md) |
 | Teclast F6 Pro | `27c6:5740` | - | No known fix | [gap-map](unsupported-devices.md) |

--- a/docs/unsupported-devices.md
+++ b/docs/unsupported-devices.md
@@ -1,6 +1,6 @@
 # Devices with no known fix (contributor gap-map)
 
-The 103 USB fingerprint sensors below are on the official libfprint
+The 102 USB fingerprint sensors below are on the official libfprint
 [Unsupported Devices](https://gitlab.freedesktop.org/libfprint/wiki/-/wikis/Unsupported-Devices)
 list and have **no working driver here or upstream**. Devices already covered by
 an entry in [`devices/`](../devices/) (working or WIP) are omitted - check the
@@ -130,7 +130,6 @@ VCSFW driver (MR [!579](https://gitlab.freedesktop.org/libfprint/libfprint/-/mer
 | `2808:9348` | - |  |
 | `2808:a553` | Focaltech FT9365, Asus VivoBook |  |
 | `2808:a658` | Asus Vivobook K6500zc |  |
-| `2df0:0003` | CanvasBio CB2000 |  |
 | `3538:0930` | External |  |
 
 _SPI sensors (ELAN7001/7002/079C, GXFP5187/51B7, GDIX51C0, fpc1020, etc.) are


### PR DESCRIPTION
Relates to #17.

Four people have independently reverse-engineered the CanvasBio CB2000 from the Samsung Windows driver, and two report daily use for login and `sudo`. None of it was catalogued anywhere, and there is no libfprint merge request for `2df0` in any state, so today you find a GitLab snippet or a fork by luck.

### What the entry records

- All five projects, with approach and licence: kpagnussat (LGPL-2.1, SIGFM, most active), LennartArnholdt (LGPL-2.1-or-later AND MIT, SIFT, documented accuracy figures), latex (MIT, standalone plus CLI tooling), rfocosi (fork, no licence stated), vgperess (earliest, no licence stated). Nothing is hosted here, we point at them, and the licences are stated so people can judge before mixing code into an LGPL-2.1 library.
- Why the sensor needs its own matcher: an 80x64 frame covering about 5x4 mm gives 0 to 3 minutiae where NBIS/bozorth3 wants roughly 20, so every working driver derives from `FpDevice` rather than `FpImageDevice` and builds a multi-frame template.

### The warning

`2df0:0007` (Galaxy Book5 360) is a different part. kpagnussat's `id_table` lists it, but nothing else in that driver branches on PID, so a `:0007` binds and is then driven with a command set traced off `:0003`. It stalls on the first vendor control request and loops on USB reset indefinitely, which is #17. Third-party notes describe `:0007` as match-on-chip with SDCP and TLS against the plain unencrypted image sensor `:0003` is known to be; recorded as unverified, because it is.

### Housekeeping

- gap-map row removed, 103 to 102
- `docs/laptops.md` regenerated, picking up Samsung Galaxy Book2 360 and Book3 360
- `python3 tools/check-repo.py` passes: 44 entries, links and files consistent