### PR TITLE
Record the 2df0:0007 descriptor evidence from issue #17

### DIFF
--- a/devices/2df0:0003/2df0-0007-lsusb.txt
+++ b/devices/2df0:0003/2df0-0007-lsusb.txt
@@ -1,0 +1,101 @@
+
+Bus 003 Device 002: ID 2df0:0007 CanvasBio CanvasBio CB2000
+Negotiated speed: High Speed (480Mbps)
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               2.01
+  bDeviceClass          239 Miscellaneous Device
+  bDeviceSubClass         2 [unknown]
+  bDeviceProtocol         1 Interface Association
+  bMaxPacketSize0        64
+  idVendor           0x2df0 CanvasBio
+  idProduct          0x0007 CanvasBio CB2000
+  bcdDevice           f0.42
+  iManufacturer           3 CanvasBio
+  iProduct                1 CanvasBio CB2000
+  iSerial                 2 201801010001
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength       0x002e
+    bNumInterfaces          1
+    bConfigurationValue     1
+    iConfiguration          4 CanvasBio CB2000
+    bmAttributes         0xa0
+      (Bus Powered)
+      Remote Wakeup
+    MaxPower              500mA
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           4
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass      2 [unknown]
+      bInterfaceProtocol      0 
+      iInterface              5 CanvasBio CB2000
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x01  EP 1 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0010  1x 16 bytes
+        bInterval               8
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x84  EP 4 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0010  1x 16 bytes
+        bInterval               8
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+Binary Object Store Descriptor:
+  bLength                 5
+  bDescriptorType        15
+  wTotalLength       0x0029
+  bNumDeviceCaps          2
+  Platform Device Capability:
+    bLength                28
+    bDescriptorType        16
+    bDevCapabilityType      5
+    bReserved               0
+    PlatformCapabilityUUID    {d8dd60df-4589-4cc7-9cd2-659d9e648a9f}
+    CapabilityData[0]    0x00
+    CapabilityData[1]    0x00
+    CapabilityData[2]    0x03
+    CapabilityData[3]    0x06
+    CapabilityData[4]    0xb0
+    CapabilityData[5]    0x01
+    CapabilityData[6]    0x15
+    CapabilityData[7]    0x00
+  ** UNRECOGNIZED:  08 10 11 01 03 00 00 00
+Device Status:     0x0000
+  (Bus Powered)

--- a/devices/2df0:0003/README.md
+++ b/devices/2df0:0003/README.md
@@ -62,10 +62,68 @@ driver, against the plain unencrypted image sensor that `:0003` is known to be.
 That is third-party and unverified, but it is consistent with a device
 rejecting a bare vendor request outright.
 
-If you have a `:0007`, the useful contribution is a full `lsusb -v` dump,
-especially the BOS descriptor, and a Windows-side USB capture if you can get
-one. Tracked in
-[issue #17](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/17).
+### What the descriptors say
+
+A full descriptor dump from a Book5 360, posted in
+[issue #17](https://github.com/jedbillyb/linux-fingerprint-drivers/issues/17),
+settles what that stall means, and a copy is kept here as
+[`2df0-0007-lsusb.txt`](2df0-0007-lsusb.txt) so it outlives the attachment
+URL. The interface is vendor specific, class 255
+subclass 2, with four endpoints:
+
+| Endpoint | Direction | Type | Max packet |
+|---|---|---|---|
+| `0x01` | OUT | Bulk | 512 |
+| `0x82` | IN | Bulk | 512 |
+| `0x83` | IN | Interrupt | 16 |
+| `0x84` | IN | Interrupt | 16 |
+
+The `:0003` driver declares only `0x01` and `0x82` and never touches either
+interrupt endpoint. Whether that is a real generational difference or just an
+unused pair on both parts is still open, because nobody has posted an
+`lsusb -v` from a working `:0003` to diff against.
+
+The BOS descriptor carries a Microsoft OS 2.0 platform capability with
+`CapabilityData` `00 00 03 06 b0 01 15 00`, decoding as a Windows 8.1 minimum,
+a 432 byte descriptor set and vendor request code `0x15`. Fetching that set
+over `bRequest=0x15` returns exactly the advertised 432 bytes, containing:
+
+- compatible ID `WINUSB`
+- `DeviceInterfaceGUID` `{62B96A71-9D46-49E7-A698-134007291217}`
+- WinUSB power properties: idle enabled, 5000 ms idle timeout, system wake
+  enabled
+
+A second BOS capability of type `0x11`, payload `01 03 00 00 00`, is present
+and lsusb does not decode it. Device revision is `bcdDevice f0.42`.
+
+### What that rules in and out
+
+**The stall is a firmware command set difference, not a broken device.** Vendor
+control transfers plainly work: `bRequest=0x15` succeeds on the same control
+endpoint where `bRequest=0xdb` stalls. The `:0007` firmware simply does not
+implement the `:0003` command vocabulary, which is what you would expect from a
+driver that was never run against it.
+
+**`WINUSB` does not settle the match-on-chip question either way.** It means
+Windows binds `winusb.sys` as the function driver and the biometric logic sits
+in a user mode WBDI driver above it. A plain image sensor and a match-on-chip
+sensor doing an SDCP handshake would look identical at this level, because the
+handshake would be spoken by that user mode driver over the same bulk
+endpoints. The
+[myso-kr notes](https://github.com/myso-kr/samsung-galaxy-book-fingerprint-sensor-device-730b/blob/main/docs/reverse-engineering/driver-analysis.md)
+describing `:0007` as match-on-chip with SDCP and TLS remain a lead, not a
+finding.
+
+**The transport is ordinary, so libusb can reproduce anything Windows sends.**
+The descriptor set is self-describing, so Windows binds without a vendor INF,
+and nothing about the link is privileged or kernel resident. The whole protocol
+therefore crosses the wire in front of any capture, and the reverse engineering
+target is the user mode component that opens that interface GUID. Searching a
+Samsung or CanvasBio driver package for the GUID string above is the way to
+find it.
+
+Still wanted: a Windows side capture, the vendor driver package, or an
+`lsusb -v` from a working `:0003` for the endpoint diff.
 
 ## Build and install
 


### PR DESCRIPTION
The Book5 360 owner in #17 posted a full `lsusb -v` for `2df0:0007` plus the
432 byte Microsoft OS 2.0 descriptor set. This folds it into the
`devices/2df0:0003` entry and archives the dump next to it so the evidence
outlives the GitHub attachment URL.

What the data establishes:

- **The stall is a firmware command set difference, not a broken device.**
  `bRequest=0x15` succeeds on the same control endpoint where the `:0003`
  driver's `bRequest=0xdb` stalls.
- **`WINUSB` plus a `DeviceInterfaceGUID` leaves the match-on-chip question
  open.** It puts the biometric logic in a user mode WBDI driver, which is what
  a plain image sensor and an SDCP sensor would both look like from here. The
  myso-kr match-on-chip claim stays labelled a lead.
- **The transport is ordinary**, so libusb can reproduce anything Windows
  sends, and the reverse engineering target is the user mode component that
  opens that interface GUID.
- `:0007` exposes two interrupt IN endpoints, `0x83` and `0x84`, that the
  `:0003` driver never touches. Whether that is generational is still open, as
  no `lsusb -v` from a working `:0003` has been posted.