### PR TITLE
Add Dell XPS 13 9370 to Goodix HTK32 (27c6:5385)

### DIFF
--- a/devices/27c6:5385/MODELS
+++ b/devices/27c6:5385/MODELS
@@ -1,3 +1,4 @@
 Dell XPS 13 9305
 Dell XPS 13 7390 2-in-1
+Dell XPS 13 9370
 Dell XPS 15 9570

--- a/devices/27c6:5385/README.md
+++ b/devices/27c6:5385/README.md
@@ -7,7 +7,7 @@ driver covers product IDs `5335`, `5385`, and `5395`.
 
 ## Hardware
 
-Seen on Dell XPS 13 9305, Dell XPS 13 7390 2-in-1, and Dell XPS 15 9570.
+Seen on Dell XPS 13 9305, Dell XPS 13 7390 2-in-1, Dell XPS 13 9370, and Dell XPS 15 9570.
 
 ## What was broken
 
@@ -56,3 +56,4 @@ Enable fprintd in your PAM stack: distro helper where there is one, otherwise
 ## Tested on
 
 - Arch Linux, Fedora, and Ubuntu/Debian, on the Dell XPS models listed above.
+- Dell XPS 13 9370 on Ubuntu 26.04: `27c6:5385`, FW `GF5288_HTSEC_APP_10011`, chip `0x220c`, GNOME enroll/unlock via [goodix53x5](https://github.com/AndyHazz/goodix53x5-libfprint). Ubuntu glue: https://github.com/larches-technologies/goodix-htk32

--- a/docs/laptops.md
+++ b/docs/laptops.md
@@ -17,7 +17,7 @@ lsusb        # find the reader, e.g. 27c6:55b4
 then look it up in the [main README](../README.md), or run
 `./tools/detect.sh` to have it matched for you.
 
-35 model listings map to a catalogued sensor; the rest are on the
+36 model listings map to a catalogued sensor; the rest are on the
 gap-map with no known fix, and a protocol dump for any of them is welcome.
 
 **Adding your machine** is the single most useful small contribution here.
@@ -64,6 +64,7 @@ in practice), **Stale** (abandoned lead), **No known fix**.
 |--------------|--------|--------|--------|-------------|
 | Dell XPS 13 7390 2-in-1 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
 | Dell XPS 13 9305 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
+| Dell XPS 13 9370 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
 | Dell XPS 15 9570 | `27c6:5385` | Goodix HTK32 | Working | [entry](../devices/27c6:5385/) |
 | Dell XPS 13 9300 | `27c6:533c` | Goodix 533c - Dell OEM TOD blob route | Working (vendor blob) | [entry](../devices/27c6:533c/) |
 | Dell XPS 15 9500 | `27c6:533c` | Goodix 533c - Dell OEM TOD blob route | Working (vendor blob) | [entry](../devices/27c6:533c/) |


### PR DESCRIPTION
Adds **Dell XPS 13 9370** to the existing `27c6:5385` HTK32 entry. Same community driver as 9305 / 7390 / 9570 ([AndyHazz/goodix53x5-libfprint](https://github.com/AndyHazz/goodix53x5-libfprint)). Not a new device ID.

Confirmed on this machine:

- Dell Inc. XPS 13 9370, board `0XXY7V`
- Ubuntu 26.04.1 LTS, kernel 7.0.0-31-generic
- USB `27c6:5385` HTMicroelectronics / Goodix Fingerprint Device / serial `HTK32`
- Firmware `GF5288_HTSEC_APP_10011`, chip `0x220c`
- `fprintd-list` shows Goodix HTK32; GNOME enrolled right-index and right-middle; unlock works
- Stock Ubuntu `libfprint-2-2` 1.95 TOD does not match this ID; `cdc_acm` false-binds until unbind

Ubuntu one-shot installer (udev + build AndyHazz over `/usr`): https://github.com/larches-technologies/goodix-htk32

`python3 tools/gen-laptop-index.py` regenerated `docs/laptops.md`.